### PR TITLE
Upgrade nix to 0.24.1, limit features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bpaf",
@@ -741,15 +741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,15 +766,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustc-demangle = "0.1"
 supports-color = "1.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = "0.23.0"
+nix = { version = "0.24.1", default-features = false, features = ["signal"] }
 
 [[bin]]
 name = "cargo-asm"


### PR DESCRIPTION
This reduces build times slightly, and removes memoffset as an indirect dependency.