### PR TITLE
Fixes compilation if --target is requested and file has dependencies.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,10 +65,11 @@ fn main() -> anyhow::Result<()> {
         compile_opts.filter = CompileFilter::from(focus);
     }
     compile_opts.cli_features = opts.cli_features.try_into()?;
+    compile_opts.build_config.requested_kinds = vec![kind];
     compile_opts.build_config.requested_profile = opts.compile_mode.into();
     compile_opts.build_config.force_rebuild = opts.force_rebuild;
 
-    let mut rustc_args = vec![
+    let rustc_args = vec![
         // so only one file gets created
         String::from("-C"),
         String::from("codegen-units=1"),
@@ -81,14 +82,6 @@ fn main() -> anyhow::Result<()> {
         String::from("-C"),
         String::from("debuginfo=2"),
     ];
-    if let Some(target) = &opts.target {
-        rustc_args.push(String::from("--target"));
-        rustc_args.push(target.to_string());
-        if let Ok(linker) = cfg.get::<String>(&format!("target.{target}.linker")) {
-            rustc_args.push(String::from("-C"));
-            rustc_args.push(format!("linker={linker}"));
-        }
-    }
     compile_opts.target_rustc_args = Some(rustc_args);
     compile_opts.build_config.build_plan = opts.dry;
 


### PR DESCRIPTION
Example source code:

```
use rand;

fn main() {
    let mut num1: i32 = rand::random();
    let mut num2: i32 = rand::random();
    num1 = num1 % 100;
    num2 = num2 % 100;
    println!("{}", num1 * num2);
}
```

Can't be printed as asm with `cargo asm learn_codegen::main -v --rust --target=x86_64-apple-darwin` on M1

It falls with :
```
error[E0461]: couldn't find crate `rand` with expected target triple x86_64-apple-darwin
 --> src/main.rs:1:5
  |
1 | use rand;
  |     ^^^^
  |
  = note: the following crate versions were found:
          crate `rand`, target triple aarch64-apple-darwin:
```
Because `asm show` builds dependencies with Host's arch.