### PR TITLE
Detect missing sources and suggest to install them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.1.19] - 2022-09-23
+- detect missing sources and suggest to install them
+
 ## [0.1.18] - 2022-09-15
 - bugfix to package selection in non-virtual workspaces
 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -550,6 +550,11 @@ pub fn dump_function(
                     };
                     if relative_path.file_name().is_some() {
                         let src = sysroot.join("lib/rustlib/src/rust").join(relative_path);
+                        if !src.exists() {
+                            eprintln!("You need to install rustc sources to be able to see the rust annotations, try\n\
+                                       \trustup component add rust-src");
+                            std::process::exit(1);
+                        }
                         if let Ok(payload) = std::fs::read_to_string(src) {
                             return (path, CachedLines::without_ending(payload));
                         }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -235,7 +235,7 @@ mod statements {
 
     impl<'a> File<'a> {
         pub fn parse(input: &'a str) -> IResult<&'a str, Self> {
-            fn filename<'a>(input: &'a str) -> IResult<&'a str, &'a str> {
+            fn filename(input: &str) -> IResult<&str, &str> {
                 delimited(tag("\""), take_while1(|c| c != '"'), tag("\""))(input)
             }
 


### PR DESCRIPTION
```
% cargo asm -p mini-std lerp32 --rust
    Finished release [optimized + debuginfo] target(s) in 0.24s
You need to install rustc sources to be able to see the rust annotations, try
        rustup component add rust-src

% rustup component add rust-src
info: downloading component 'rust-src'
info: installing component 'rust-src'
% cargo asm -p mini-std lerp32 --rust
    Finished release [optimized + debuginfo] target(s) in 0.23s
mini_std::math::lerp32:
.Lfunc_begin39:
...
```