### PR TITLE
Expose cargo's vendored-openssl feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "opener",
+ "openssl",
  "os_info",
  "pathdiff",
  "percent-encoding",
@@ -846,6 +847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +864,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ supports-color = "1.3"
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { version = "0.25", default-features = false, features = ["signal"] }
 
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]
+
 [[bin]]
 name = "cargo-asm"
 path = "src/main.rs"


### PR DESCRIPTION
The openssl installation situation on macOS is terrible 🤝 horrible 🤝 no good 🤝 very bad, so it's common for applications that depend on `cargo` to expose this alternative.

- https://github.com/kbknapp/cargo-outdated/blob/v0.11.1/Cargo.toml#L50
- https://github.com/rust-secure-code/cargo-geiger/blob/cargo-geiger-0.11.4/cargo-geiger/Cargo.toml#L39
- https://github.com/est31/cargo-udeps/blob/v0.1.32/Cargo.toml#L16
- https://github.com/nabijaczleweli/cargo-update/blob/v8.2.0/Cargo.toml#L92

Without vendored openssl, installation fails on macOS with:
<details>
<summary>...</summary>

```console
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "-arch" "arm64" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/rustcgAqSq1/symbols.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.0.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.1.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.10.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.11.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.12.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.13.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.14.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.15.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.2.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.3.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.4.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.5.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.6.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.7.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.8.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.cargo_asm.65085fea-cgu.9.rcgu.o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4.1nfh02nhkv6wb58x.rcgu.o" "-L" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps" "-L" "/Library/Developer/CommandLineTools/usr/lib/clang/14.0.0/lib/darwin" "-L" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/build/curl-sys-16581f558844e8af/out/build" "-L" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/build/libnghttp2-sys-9e014bc14badb56b/out/i/lib" "-L" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/build/libgit2-sys-9f995afbb98cc2a6/out/build" "-L" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/build/libssh2-sys-e07d767d7ab8109f/out/build" "-L" "/opt/homebrew/opt/openssl@1.1/lib" "-L" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libnix-77e85ae2fb160341.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcargo_show_asm-9a313f94992d55bd.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbpaf-319888e6bdc2812f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/librustc_demangle-8da27d01b9535a9d.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libline_span-fb44aa64abe5be9a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libowo_colors-34c4809a8198136c.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libsupports_color-ee6085e6cedacbe1.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libis_ci-5b8b8ad03009e06b.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libnom-304afc55baffbbf9.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcargo-585e38fadba30766.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libhome-0825e40e20aa4bdb.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libopener-edfc78d81722a1d6.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libunicode_xid-33f78e40fdda1410.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libim_rc-86404f2a434c3535.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/librand_xoshiro-66c3b77f96f01328.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/librand_core-9b9eb45c286139c7.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libsized_chunks-15404f2ffc82b564.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbitmaps-c79ceacb7dc499ab.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtypenum-d7937aee5846db6e.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libhumantime-0d0ce8c0eaf88389.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libstrip_ansi_escapes-deee50f2ffb59566.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libvte-44d7618409c97fea.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libutf8parse-251859f1dc7ea2c7.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libarrayvec-1be44790d86c58c4.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libnum_cpus-21d3624b0cec72c4.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libserde_ignored-7d03830ecfb0957a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libunicode_width-8bf8129c5d0ae63c.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libclap-625a6b63e14aa078.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libatty-f8d4e462c36400da.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libstrsim-90b63ed9f828463f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtextwrap-b06c9c339731a808.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libclap_lex-00db473b72f3044f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libos_str_bytes-44b646024f96e99b.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libignore-987a142013878f99.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblazy_static-ebd75cc0f36ef66d.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libthread_local-5197f7cd4fa56206.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libglobset-691a6453ae07744f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libfnv-0419508d61057d71.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libregex-b3a5da7950c531ea.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libregex_syntax-37daa5846bec1b7a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbstr-daac985e30352ff7.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libaho_corasick-44225d686fef2bf8.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libgit2-44ff6d8f2a0c6e2f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblibgit2_sys-cd51a0f1e0eeaf87.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblibssh2_sys-41a7260dd55df7e7.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libopenssl_sys-55fbcd6e30b7a99f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbitflags-2bbfbfade6407190.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcrates_io-d033f0fdf515cbb2.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/librustfix-90d0d891e48d5707.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtar-3853731d3d50e607.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libflate2-aabcdb8cd1f1563e.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcrc32fast-54beddddea2cb5fc.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libserde_json-df3e11ee9f0bbabb.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libryu-ef0db24e0432c9b6.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libitoa-d63aebe64377efe5.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libpathdiff-cc2c38718339dc47.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libglob-557e930271e9e9d9.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtermcolor-ff0126ae5373e748.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcurl-58012c2e337815c3.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libsocket2-157b84509ff1217e.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcurl_sys-67acb1f1af16adc3.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblibz_sys-5866fff99dc59df3.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblibnghttp2_sys-b66de93ecd66de72.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbytesize-1b4bf0585bb5e656.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtoml_edit-538f9a9decf4bc3a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libkstring-7db2b69cd1c33f04.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libstatic_assertions-4f0dc294aab23062.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libindexmap-cb088934ecb46261.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libhashbrown-fe8315aebe5807ae.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libitertools-dd634c1bb60f04aa.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libeither-e010383f73d8ad9f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcombine-ac48ec15eaf3058e.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libmemchr-b9afceb11d89c5ca.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libbytes-cd93eda7ae369d96.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liburl-a9fb294bd6bb64b7.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libidna-11f8ac9e74f8a505.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libunicode_normalization-ee648b9945147e9c.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtinyvec-578cef4b7f7be158.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtinyvec_macros-b04713a4a486580f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libunicode_bidi-e31b0e7e02283d3f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libform_urlencoded-32bf11090fdb154b.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libpercent_encoding-f826ffdab1c80872.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libsemver-b4cb5168b9103ff6.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcrossbeam_utils-3bdcc89448c5cf50.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libonce_cell-c54d016c78b1353d.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblazycell-86ef46abe9bbfb41.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcargo_platform-7f8ddc7cbd933a30.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libserde-c947d6b98d72dbfd.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcargo_util-f5989f02cb9bbbe5.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libhex-713e61cc6c8ebcc5.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libwalkdir-6a288a184e4d818e.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libsame_file-097311bb4d87b294.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcrypto_hash-676e66d200acd7d8.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libhex-4f1306b805de157a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcommoncrypto-87164eb4c489fcd0.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcommoncrypto_sys-721a72e61fd2fe7a.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libshell_escape-28af3f573957ea13.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libjobserver-cd91b4e6b9dd9226.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcore_foundation-14811339abb593c0.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcore_foundation_sys-7eee4972737996ee.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libtempfile-8699395f06a55106.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libfastrand-fcefc726ebcf7521.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libremove_dir_all-5ec04e9bf355307f.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libfiletime-ab9e9a0e337c9ffb.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblibc-620aa76d71f28a45.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/liblog-ce89bebd7bfd835b.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libcfg_if-0692cee5d0087e61.rlib" "/private/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/libanyhow-255aedc66112ab9f.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-2a5c2e72f36cb3e5.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libpanic_unwind-5d6c50a5511d5b38.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libobject-44703751ec754c6f.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libmemchr-d6f3bfbb73711004.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libaddr2line-44af0db03be329d2.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libgimli-9dc78b50bf1c45c0.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_demangle-8697aceef2377a94.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd_detect-f73601afb512f85e.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-bcce83c0fca5d510.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libhashbrown-a80be289d3b85f20.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libminiz_oxide-85181678fc783242.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libadler-4e642e6b12910c5b.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_alloc-b67175a3e890da31.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libunwind-1ba63ac4e9539424.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-58428a237963e73e.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liblibc-7512abb04e6cb940.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liballoc-880986a981365e05.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_core-a8a859a864856684.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcore-908209eee60fb642.rlib" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-cb46d4fa30adb098.rlib" "-liconv" "-framework" "Security" "-framework" "CoreFoundation" "-lssl" "-lcrypto" "-lclang_rt.osx" "-framework" "Security" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-lz" "-framework" "CoreFoundation" "-liconv" "-lSystem" "-lresolv" "-lc" "-lm" "-liconv" "-L" "/Users/dtolnay/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/var/folders/jm/n9f0cy6n27n2cr0q4l3009dw0000gn/T/cargo-installjrGGsg/release/deps/cargo_asm-59b9c7450fe24ef4" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: ld: warning: ignoring file /opt/homebrew/opt/openssl@1.1/lib/libssl.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
          ld: warning: ignoring file /opt/homebrew/opt/openssl@1.1/lib/libcrypto.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
          Undefined symbols for architecture arm64:
            "_BIO_ctrl", referenced from:
                __libssh2_pub_priv_keyfile in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfilememory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BIO_free", referenced from:
                __libssh2_rsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_rsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ed25519_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_BIO_new_file", referenced from:
                __libssh2_rsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfile in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BIO_new_mem_buf", referenced from:
                __libssh2_rsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ed25519_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfilememory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BN_CTX_free", referenced from:
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _diffie_hellman_sha_algo in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
            "_BN_CTX_new", referenced from:
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _diffie_hellman_sha_algo in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
            "_BN_bin2bn", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_BN_bn2bin", referenced from:
                __libssh2_dsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_curve25519_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _ecdh_sha2_nistp in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _diffie_hellman_sha_algo in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_BN_clear_free", referenced from:
                __libssh2_dh_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_curve25519_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _ecdh_sha2_nistp in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _kex_method_diffie_hellman_group_exchange_sha256_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _diffie_hellman_sha_algo in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _kex_method_diffie_hellman_group16_sha512_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_BN_div", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BN_mod_exp", referenced from:
                __libssh2_dh_key_pair in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dh_secret in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BN_new", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dh_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_BN_num_bits", referenced from:
                __libssh2_dsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_curve25519_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _ecdh_sha2_nistp in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _diffie_hellman_sha_algo in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_BN_rand", referenced from:
                __libssh2_dh_key_pair in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BN_set_word", referenced from:
                _kex_method_diffie_hellman_group16_sha512_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _kex_method_diffie_hellman_group18_sha512_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _kex_method_diffie_hellman_group14_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                _kex_method_diffie_hellman_group1_sha1_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
            "_BN_sub", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_BN_value_one", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_SIG_free", referenced from:
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_SIG_get0", referenced from:
                __libssh2_dsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_SIG_new", referenced from:
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_SIG_set0", referenced from:
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_do_sign", referenced from:
                __libssh2_dsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_do_verify", referenced from:
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_free", referenced from:
                _hostkey_method_ssh_dss_init in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_initPEM in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_initPEMFromMemory in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_dsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_get0_key", referenced from:
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_get0_pqg", referenced from:
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_new", referenced from:
                __libssh2_dsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_set0_key", referenced from:
                __libssh2_dsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_DSA_set0_pqg", referenced from:
                __libssh2_dsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDH_compute_key", referenced from:
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_SIG_free", referenced from:
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_SIG_get0", referenced from:
                __libssh2_ecdsa_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_SIG_new", referenced from:
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_SIG_set0", referenced from:
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_do_sign", referenced from:
                __libssh2_ecdsa_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ECDSA_do_verify", referenced from:
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_GROUP_get_curve_name", referenced from:
                __libssh2_ecdsa_get_curve_type in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_GROUP_get_degree", referenced from:
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_KEY_free", referenced from:
                _hostkey_method_ssh_ecdsa_init in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ecdsa_initPEM in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ecdsa_initPEMFromMemory in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ecdsa_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_ecdh_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_EC_KEY_generate_key", referenced from:
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_KEY_get0_group", referenced from:
                __libssh2_ecdsa_get_curve_type in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EC_KEY_get0_public_key", referenced from:
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_KEY_new_by_curve_name", referenced from:
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_KEY_set_private_key", referenced from:
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_KEY_set_public_key", referenced from:
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_POINT_free", referenced from:
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_POINT_new", referenced from:
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_POINT_oct2point", referenced from:
                __libssh2_ecdsa_curve_name_with_octal_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdh_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EC_POINT_point2oct", referenced from:
                __libssh2_ecdsa_create_key in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ENGINE_load_builtin_engines", referenced from:
                __libssh2_openssl_crypto_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_ENGINE_register_all_complete", referenced from:
                __libssh2_openssl_crypto_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_CIPHER_CTX_free", referenced from:
                _crypt_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_CIPHER_CTX_new", referenced from:
                __libssh2_cipher_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_Cipher", referenced from:
                __libssh2_cipher_crypt in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_CipherInit", referenced from:
                __libssh2_cipher_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_DigestFinal", referenced from:
                _hostkey_method_ssh_ecdsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_curve25519_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_EVP_DigestInit", referenced from:
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha1_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha256_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha384_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha512_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EVP_DigestSign", referenced from:
                __libssh2_ed25519_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_DigestSignInit", referenced from:
                __libssh2_ed25519_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_DigestUpdate", referenced from:
                _hostkey_method_ssh_ecdsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _kex_method_curve25519_key_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                ...
            "_EVP_DigestVerify", referenced from:
                __libssh2_ed25519_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_DigestVerifyInit", referenced from:
                __libssh2_ed25519_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_MD_CTX_free", referenced from:
                _hostkey_method_ssh_ecdsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_dss_signv in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha1_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EVP_MD_CTX_new", referenced from:
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha1_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha256_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha384_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha512_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EVP_PKEY_CTX_free", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_CTX_new", referenced from:
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_CTX_new_id", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_derive", referenced from:
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_derive_init", referenced from:
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_derive_set_peer", referenced from:
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_free", referenced from:
                _hostkey_method_ssh_ed25519_init in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ed25519_initPEM in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ed25519_initPEMFromMemory in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_ed25519_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ed25519_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ed25519_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EVP_PKEY_get1_DSA", referenced from:
                _gen_publickey_from_dsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_get1_EC_KEY", referenced from:
                _gen_publickey_from_ec_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_get1_RSA", referenced from:
                _gen_publickey_from_rsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_get_raw_private_key", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_get_raw_public_key", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ed_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_id", referenced from:
                __libssh2_ed25519_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfile in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfilememory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_keygen", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_keygen_init", referenced from:
                __libssh2_curve25519_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_new", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_dsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_new_raw_private_key", referenced from:
                _gen_publickey_from_ed25519_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_new_raw_public_key", referenced from:
                __libssh2_ed25519_new_public in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_curve25519_gen_k in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_set1_DSA", referenced from:
                _gen_publickey_from_dsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_set1_EC_KEY", referenced from:
                _gen_publickey_from_ecdsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_PKEY_set1_RSA", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_EVP_aes_128_cbc", referenced from:
                _libssh2_crypt_method_aes128_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_aes_128_ctr", referenced from:
                _libssh2_crypt_method_aes128_ctr in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_aes_192_cbc", referenced from:
                _libssh2_crypt_method_aes192_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_aes_192_ctr", referenced from:
                _libssh2_crypt_method_aes192_ctr in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_aes_256_cbc", referenced from:
                _libssh2_crypt_method_aes256_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
                _libssh2_crypt_method_rijndael_cbc_lysator_liu_se in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_aes_256_ctr", referenced from:
                _libssh2_crypt_method_aes256_ctr in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_bf_cbc", referenced from:
                _libssh2_crypt_method_blowfish_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_cast5_cbc", referenced from:
                _libssh2_crypt_method_cast128_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_des_ede3_cbc", referenced from:
                _libssh2_crypt_method_3des_cbc in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_get_digestbyname", referenced from:
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha1_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha256_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha384_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_sha512_init in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                ...
            "_EVP_md5", referenced from:
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_EVP_rc4", referenced from:
                _libssh2_crypt_method_arcfour128 in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
                _libssh2_crypt_method_arcfour in liblibssh2_sys-41a7260dd55df7e7.rlib(crypt.o)
            "_EVP_ripemd160", referenced from:
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_EVP_sha1", referenced from:
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_EVP_sha256", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_EVP_sha512", referenced from:
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_HMAC_CTX_free", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_HMAC_CTX_new", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_HMAC_Final", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_HMAC_Init_ex", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_HMAC_Update", referenced from:
                _mac_method_hmac_sha2_256_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha2_512_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_sha1_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_md5_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
                _mac_method_hmac_ripemd160_hash in liblibssh2_sys-41a7260dd55df7e7.rlib(mac.o)
            "_OPENSSL_init_ssl", referenced from:
                std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::h2c2f6429eca48f53 (.llvm.3000087089510908475) in libopenssl_sys-55fbcd6e30b7a99f.rlib(openssl_sys-55fbcd6e30b7a99f.openssl_sys.287fef1f-cgu.7.rcgu.o)
                core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hb38f9b26fae66a12 (.llvm.3000087089510908475) in libopenssl_sys-55fbcd6e30b7a99f.rlib(openssl_sys-55fbcd6e30b7a99f.openssl_sys.287fef1f-cgu.7.rcgu.o)
            "_PEM_read_bio_DSAPrivateKey", referenced from:
                __libssh2_dsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_dsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_PEM_read_bio_ECPrivateKey", referenced from:
                __libssh2_ecdsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_ecdsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_PEM_read_bio_PrivateKey", referenced from:
                __libssh2_ed25519_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfile in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_pub_priv_keyfilememory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_PEM_read_bio_RSAPrivateKey", referenced from:
                __libssh2_rsa_new_private_frommemory in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                __libssh2_rsa_new_private in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RAND_bytes", referenced from:
                __libssh2_kex_exchange in liblibssh2_sys-41a7260dd55df7e7.rlib(kex.o)
                __libssh2_transport_send in liblibssh2_sys-41a7260dd55df7e7.rlib(transport.o)
            "_RSA_free", referenced from:
                _hostkey_method_ssh_rsa_init in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_initPEM in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_initPEMFromMemory in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _hostkey_method_ssh_rsa_dtor in liblibssh2_sys-41a7260dd55df7e7.rlib(hostkey.o)
                _gen_publickey_from_rsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_get0_factors", referenced from:
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_get0_key", referenced from:
                _gen_publickey_from_rsa_evp in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_new", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_set0_crt_params", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
                _gen_publickey_from_rsa_openssh_priv_data in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_set0_factors", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_set0_key", referenced from:
                __libssh2_rsa_new in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_sign", referenced from:
                __libssh2_rsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_size", referenced from:
                __libssh2_rsa_sha1_sign in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
            "_RSA_verify", referenced from:
                __libssh2_rsa_sha1_verify in liblibssh2_sys-41a7260dd55df7e7.rlib(openssl.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
</details>