### PR TITLE
Delabel followup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26b84feed0bdb469496d0aef81ff5a0c26265e28aff4e12b14bd6437a5503e8"
+checksum = "42efc66e688b6433a6763382c4edda86483ec063e5f18e929c31f70d69c29c02"
 dependencies = [
  "bpaf_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bpaf = { version = "0.6", features = ["bpaf_derive", "autocomplete"] }
+bpaf = { version = "0.6.1", features = ["bpaf_derive", "autocomplete"] }
 cargo = "0.65"
 git2 = { version = "0.14.2", optional = true } # same version as used by cargo
 line-span = "0.1"

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -114,6 +114,7 @@ pub fn dump_range(sysroot: &Path, fmt: &Format, stmts: &[Statement]) -> anyhow::
         used_labels(stmts)
     };
 
+    let mut empty_line = false;
     for line in stmts.iter() {
         if let Statement::Directive(Directive::File(f)) = line {
             if !fmt.rust {
@@ -171,12 +172,14 @@ pub fn dump_range(sysroot: &Path, fmt: &Format, stmts: &[Statement]) -> anyhow::
                 if let Statement::Label(Label { local: true, id }) = line {
                     if used.contains_key(id) {
                         println!("{line}");
-                    } else {
+                    } else if !empty_line {
                         println!();
+                        empty_line = true;
                     }
                     continue;
                 }
             }
+            empty_line = false;
 
             #[allow(clippy::collapsible_else_if)]
             if fmt.full_name {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -45,7 +45,7 @@ fn find_items(lines: &[Statement]) -> BTreeMap<Item, Range<usize>> {
     let mut res = BTreeMap::new();
 
     let mut sec_start = 0;
-    let mut item = None;
+    let mut item: Option<Item> = None;
     let mut names = BTreeMap::new();
 
     for (ix, line) in lines.iter().enumerate() {
@@ -54,7 +54,8 @@ fn find_items(lines: &[Statement]) -> BTreeMap<Item, Range<usize>> {
         } else if line.is_end_of_fn() {
             let sec_end = ix;
             let range = sec_start..sec_end;
-            if let Some(item) = item.take() {
+            if let Some(mut item) = item.take() {
+                item.len = ix - item.len;
                 res.insert(item, range);
             }
         } else if let Statement::Label(label) = line {


### PR DESCRIPTION
Fixes #31

Proper relative label renaming is mildly annoying since it is affected by printing/not printing rust code, empty line deduplication and so on.