### PR TITLE
Release 0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.1.22] - unreleased
+## [0.1.22] - 2022-10-03
 - strip redundant labels by default
 - cleaning up
 - removing glob in favor of std::fs - windows CI now works


### PR DESCRIPTION
- strip redundant labels by default
- removing `glob` in `favor of std::fs` - windows CI now works
- document completions
