### PR TITLE
Prepare to release 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bpaf"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae66dbe2fc91a862d1af3214746f9a5e451d58b76b5f28e5174e5ee920bc316"
+checksum = "a1eefd44fa3be02b360bb22b44abaf204fb381baf5d2f24e270f58bb42dc3e73"
 dependencies = [
  "bpaf_derive",
  "owo-colors",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bpaf",
@@ -140,9 +140,9 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "libc"
-version = "0.2.136"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "line-span"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "owo-colors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bpaf = { version = "0.7.1", features = ["bpaf_derive", "autocomplete"] }
+bpaf = { version = "0.7.2", features = ["bpaf_derive", "autocomplete"] }
 cargo_metadata = "0.15.1"
 line-span = "0.1"
 nom = "7"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.1] - 2022-10-29
+- number of MacOS specific bugfixes
+- update deps
+- more detailed output with verbosity flags
+
 ## [0.2.0] - 2022-10-22
 - replaced libcargo with invoking cargo
 Thanks to @oxalica

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ cargo install cargo-show-asm
 
 - Platform support:
 
-  - OS: Linux and MacOSX. Limited support for Windows
+  - OS: Linux and MacOS. Limited support for Windows
   - Rust: nightly and stable.
   - Architectures: `x86`, `x86_64`, `aarch64`, etc.
   - Cross-compilation support.


### PR DESCRIPTION
- number of MacOS specific bugfixes
- update deps
- more detailed output with verbosity flags

Fixes #76 
