### PR TITLE
Prepare to release 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.2.4] - 2022-11-12
+- `--simplify` option - to strip some of the things that are not cpu instructions
+   from the asm output
+
 ## [0.2.3] - 2022-11-05
 - support rlib projects + tests
 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -154,6 +154,10 @@ pub fn dump_range(
                 empty_line = true;
             }
         } else {
+            if fmt.simplify && matches!(line, Statement::Directive(_) | Statement::Dunno(_)) {
+                continue;
+            }
+
             empty_line = false;
             #[allow(clippy::match_bool)]
             match fmt.full_name {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -179,6 +179,9 @@ pub struct Format {
     /// more verbose output, can be specified multiple times
     #[bpaf(external)]
     pub verbosity: usize,
+
+    /// Try to strip some of the non-assembly instruction information
+    pub simplify: bool,
 }
 
 #[derive(Debug, Clone, Bpaf)]


### PR DESCRIPTION
`--simplify` option to strip some of the redundant info

Fixes https://github.com/pacak/cargo-show-asm/issues/86