### PR TITLE
Improve labels and add more coloring

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 use crate::asm::statements::Label;
 use crate::cached_lines::CachedLines;
+use crate::demangle::LabelKind;
 use crate::{color, demangle};
 // TODO, use https://sourceware.org/binutils/docs/as/index.html
 use crate::opts::Format;
@@ -146,10 +147,14 @@ pub fn dump_range(
                 );
             }
             empty_line = false;
-        } else if let Statement::Label(Label { local: true, id }) = line {
+        } else if let Statement::Label(Label {
+            kind: kind @ (LabelKind::Local | LabelKind::Temp),
+            id,
+        }) = line
+        {
             if fmt.keep_labels || used.contains(id) {
                 println!("{line}");
-            } else if !empty_line && !demangle::is_temp_label(id) {
+            } else if !empty_line && *kind != LabelKind::Temp {
                 println!();
                 empty_line = true;
             }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -119,6 +119,7 @@ pub fn dump_range(
         used_labels(stmts)
     };
 
+    let mut empty_line = false;
     for line in stmts.iter() {
         if fmt.verbosity > 2 {
             println!("{line:?}");
@@ -144,15 +145,20 @@ pub fn dump_range(
                     color!(rust_line.trim_start(), OwoColorize::bright_red)
                 );
             }
+            empty_line = false;
         } else if let Statement::Label(Label { local: true, id }) = line {
             if fmt.keep_labels || used.contains(id) {
                 println!("{line}");
+            } else if !empty_line && !demangle::is_temp_label(id) {
+                println!();
+                empty_line = true;
             }
         } else {
             if fmt.simplify && matches!(line, Statement::Directive(_) | Statement::Dunno(_)) {
                 continue;
             }
 
+            empty_line = false;
             #[allow(clippy::match_bool)]
             match fmt.full_name {
                 true => println!("{line:#}"),

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -119,7 +119,6 @@ pub fn dump_range(
         used_labels(stmts)
     };
 
-    let mut empty_line = false;
     for line in stmts.iter() {
         if fmt.verbosity > 2 {
             println!("{line:?}");
@@ -145,20 +144,15 @@ pub fn dump_range(
                     color!(rust_line.trim_start(), OwoColorize::bright_red)
                 );
             }
-            empty_line = false;
         } else if let Statement::Label(Label { local: true, id }) = line {
             if fmt.keep_labels || used.contains(id) {
                 println!("{line}");
-            } else if !empty_line {
-                println!();
-                empty_line = true;
             }
         } else {
             if fmt.simplify && matches!(line, Statement::Directive(_) | Statement::Dunno(_)) {
                 continue;
             }
 
-            empty_line = false;
             #[allow(clippy::match_bool)]
             match fmt.full_name {
                 true => println!("{line:#}"),

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -284,6 +284,16 @@ fn test_parse_label() {
         ))
     );
     assert_eq!(
+        Label::parse("__ZN4core3ptr50drop_in_place$LT$rand..rngs..thread..ThreadRng$GT$17hba90ed09529257ccE:"),
+        Ok((
+            "",
+            Label {
+                id: "__ZN4core3ptr50drop_in_place$LT$rand..rngs..thread..ThreadRng$GT$17hba90ed09529257ccE",
+                kind: LabelKind::Gobal,
+            }
+        ))
+    );
+    assert_eq!(
         Label::parse(".Lexception0:"),
         Ok((
             "",

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -174,7 +174,7 @@ impl<'a> Label<'a> {
         map(
             terminated(take_while1(good_for_label), tag(":")),
             |id: &str| {
-                let local = id.starts_with(".L");
+                let local = id.starts_with(".L") || id.starts_with("LBB") || id.starts_with("Ltmp");
                 Label { id, local }
             },
         )(input)

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -174,9 +174,9 @@ impl<'a> Label<'a> {
         // TODO: label can't start with a digit
         map(
             terminated(take_while1(good_for_label), tag(":")),
-            |id: &str| {
-                let local = id.starts_with(".L") || id.starts_with("LBB") || id.starts_with("Ltmp");
-                Label { id, local }
+            |id: &str| Label {
+                id,
+                local: demangle::is_local(id),
             },
         )(input)
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -52,7 +52,20 @@ impl std::fmt::Display for Instruction<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", color!(self.op, OwoColorize::bright_blue))?;
         if let Some(args) = self.args {
-            write!(f, " {}", demangle::contents(args, f.alternate()))?;
+            let args = demangle::contents(args, f.alternate());
+            let args = args.as_ref();
+            let mut prev = 0;
+            f.write_str(" ")?;
+
+            for label in demangle::local_labels(args) {
+                // write all before the first label and between each label
+                f.write_str(&args[prev..label.start()])?;
+                write!(f, "{}", color!(label.as_str(), OwoColorize::bright_black))?;
+                prev = label.end();
+            }
+
+            // write all remaining arguments
+            f.write_str(&args[prev..])?;
         }
         Ok(())
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for Instruction<'_> {
         write!(f, "{}", color!(self.op, OwoColorize::bright_blue))?;
         if let Some(args) = self.args {
             let args = demangle::contents(args, f.alternate());
-            write!(f, " {}", demangle::color_labels(&args))?;
+            write!(f, " {}", demangle::color_local_labels(&args))?;
         }
         Ok(())
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -53,19 +53,7 @@ impl std::fmt::Display for Instruction<'_> {
         write!(f, "{}", color!(self.op, OwoColorize::bright_blue))?;
         if let Some(args) = self.args {
             let args = demangle::contents(args, f.alternate());
-            let args = args.as_ref();
-            let mut prev = 0;
-            f.write_str(" ")?;
-
-            for label in demangle::local_labels(args) {
-                // write all before the first label and between each label
-                f.write_str(&args[prev..label.start()])?;
-                write!(f, "{}", color!(label.as_str(), OwoColorize::bright_black))?;
-                prev = label.end();
-            }
-
-            // write all remaining arguments
-            f.write_str(&args[prev..])?;
+            write!(f, " {}", demangle::color_labels(&args))?;
         }
         Ok(())
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -289,7 +289,7 @@ fn test_parse_label() {
             "",
             Label {
                 id: "__ZN4core3ptr50drop_in_place$LT$rand..rngs..thread..ThreadRng$GT$17hba90ed09529257ccE",
-                kind: LabelKind::Gobal,
+                kind: LabelKind::Global,
             }
         ))
     );

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -36,12 +36,19 @@ static LOCAL_LABELS: Lazy<Regex> = Lazy::new(|| {
         .expect("regexp should be valid")
 });
 
+static TEMP_LABELS: Lazy<Regex> =
+    Lazy::new(|| regex::Regex::new(r"(Ltmp[0-9]+)").expect("regexp should be valid"));
+
 pub fn local_labels(input: &str) -> regex::Matches {
     LOCAL_LABELS.find_iter(input)
 }
 
 pub fn is_local(input: &str) -> bool {
     LOCAL_LABELS.is_match(input)
+}
+
+pub fn is_temp_label(input: &str) -> bool {
+    TEMP_LABELS.is_match(input)
 }
 
 struct LabelColorizer;

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -40,6 +40,18 @@ pub fn local_labels(input: &str) -> regex::Matches {
     LOCAL_LABELS.find_iter(input)
 }
 
+struct LabelColorizer;
+impl Replacer for LabelColorizer {
+    fn replace_append(&mut self, caps: &regex::Captures<'_>, dst: &mut String) {
+        use std::fmt::Write;
+        write!(dst, "{}", color!(&caps[0], OwoColorize::bright_black)).unwrap();
+    }
+}
+
+pub fn color_labels(input: &str) -> Cow<'_, str> {
+    LOCAL_LABELS.replace_all(input, LabelColorizer)
+}
+
 struct Demangler {
     full_name: bool,
 }

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -40,6 +40,10 @@ pub fn local_labels(input: &str) -> regex::Matches {
     LOCAL_LABELS.find_iter(input)
 }
 
+pub fn is_local(input: &str) -> bool {
+    LOCAL_LABELS.is_match(input)
+}
+
 struct LabelColorizer;
 impl Replacer for LabelColorizer {
     fn replace_append(&mut self, caps: &regex::Captures<'_>, dst: &mut String) {

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -21,7 +21,7 @@ pub fn demangled(input: &str) -> Option<Demangle> {
     Some(name)
 }
 
-const GLOBAL_LABELS_REGEX: &str = r"_?(_[a-zA-Z0-9_$\.]+)";
+const GLOBAL_LABELS_REGEX: &str = r"^_?(_[a-zA-Z0-9_$\.]+)$";
 
 // This regex is two parts
 // 1. \.L[a-zA-Z0-9_$\.]+
@@ -29,9 +29,9 @@ const GLOBAL_LABELS_REGEX: &str = r"_?(_[a-zA-Z0-9_$\.]+)";
 // Label kind 1. is a standard label format for GCC and Clang (LLVM)
 // Label kinds 2. was detected in the wild, and don't seem to be a normal label format
 // however it's important to detect them so they can be colored and possibily removed
-const LOCAL_LABELS_REGEX: &str = r"(\.L[a-zA-Z0-9_$\.]+|LBB[0-9_]+)";
+const LOCAL_LABELS_REGEX: &str = r"^(\.L[a-zA-Z0-9_$\.]+|LBB[0-9_]+)$";
 
-const TEMP_LABELS_REGEX: &str = r"(Ltmp[0-9]+)";
+const TEMP_LABELS_REGEX: &str = r"^(Ltmp[0-9]+)$";
 
 static GLOBAL_LABELS: Lazy<Regex> =
     Lazy::new(|| regex::Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -54,7 +54,7 @@ static LABEL_KINDS: Lazy<RegexSet> = Lazy::new(|| {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabelKind {
-    Gobal,
+    Global,
     Local,
     Temp,
     Unknown,
@@ -66,7 +66,7 @@ pub fn local_labels(input: &str) -> regex::Matches {
 
 pub fn label_kind(input: &str) -> LabelKind {
     match LABEL_KINDS.matches(input).into_iter().next() {
-        Some(1) => LabelKind::Gobal,
+        Some(1) => LabelKind::Global,
         Some(0) => LabelKind::Local,
         Some(2) => LabelKind::Temp,
         _ => LabelKind::Unknown,

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -21,17 +21,25 @@ pub fn demangled(input: &str) -> Option<Demangle> {
     Some(name)
 }
 
-const GLOBAL_LABELS_REGEX: &str = r"^_?(_[a-zA-Z0-9_$\.]+)$";
+const GLOBAL_LABELS_REGEX: &str = r"\b_?(_[a-zA-Z0-9_$\.]+)";
 
 // This regex is two parts
 // 1. \.L[a-zA-Z0-9_$\.]+
 // 2. LBB[0-9_]+
 // Label kind 1. is a standard label format for GCC and Clang (LLVM)
 // Label kinds 2. was detected in the wild, and don't seem to be a normal label format
-// however it's important to detect them so they can be colored and possibily removed
-const LOCAL_LABELS_REGEX: &str = r"^(\.L[a-zA-Z0-9_$\.]+|LBB[0-9_]+)$";
+// however it's important to detect them so they can be colored and possibly removed
+//
+// Note on `(?:[^\w\d\$\.]|^)`. This is to prevent the label from matching in the middle of some other word
+// since \b doesn't match before a `.` we can't use \b. So instead we're using a negation of any character
+// that could come up in the label OR the beginning of the text. It's not matching because we don't care what's
+// there  as long as it doesn't look like a label.
+//
+// Note: this rejects "labels" like `H.Lfoo` but accepts `.Lexception` and `[some + .Label]`
+const LOCAL_LABELS_REGEX: &str = r"(?:[^\w\d\$\.]|^)(\.L[a-zA-Z0-9_\$\.]+|\bLBB[0-9_]+)";
 
-const TEMP_LABELS_REGEX: &str = r"^(Ltmp[0-9]+)$";
+// temporary labels
+const TEMP_LABELS_REGEX: &str = r"\b(Ltmp[0-9]+)\b";
 
 static GLOBAL_LABELS: Lazy<Regex> =
     Lazy::new(|| regex::Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -24,8 +24,17 @@ pub fn demangled(input: &str) -> Option<Demangle> {
 static GLOBAL_LABELS: Lazy<Regex> =
     Lazy::new(|| regex::Regex::new(r"_?(_[a-zA-Z0-9_$\.]+)").expect("regexp should be valid"));
 
-static LOCAL_LABELS: Lazy<Regex> =
-    Lazy::new(|| regex::Regex::new(r"(\.L[a-zA-Z0-9_$\.]+)").expect("regexp should be valid"));
+static LOCAL_LABELS: Lazy<Regex> = Lazy::new(|| {
+    // This regex is three parts
+    // 1. \.L[a-zA-Z0-9_$\.]+
+    // 2. Ltmp[0-9]+
+    // 3. LBB[0-9_]+
+    // Label kind 1. is a standard label format for GCC and Clang (LLVM)
+    // Label kinds 2. and 3. were detected in the wild, and don't seem to be a normal label format
+    // however it's important to detect them so they can be colored and possibily removed
+    regex::Regex::new(r"(\.L[a-zA-Z0-9_$\.]+|Ltmp[0-9]+|LBB[0-9_]+)")
+        .expect("regexp should be valid")
+});
 
 pub fn local_labels(input: &str) -> regex::Matches {
     LOCAL_LABELS.find_iter(input)

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -73,7 +73,7 @@ impl Replacer for LabelColorizer {
     }
 }
 
-pub fn color_labels(input: &str) -> Cow<'_, str> {
+pub fn color_local_labels(input: &str) -> Cow<'_, str> {
     LOCAL_LABELS.replace_all(input, LabelColorizer)
 }
 


### PR DESCRIPTION
This PR adds a few things
* detection for new local label types like `LBB0_1` and `Ltmp12`
* colorizing labels in arguments
* packing the assembly together (this last one could be optional behind a flag, but I really like the packed look)

See before and after below.
A few things to note:
* the many `Ltmp*` labels went away (which is super nice!)
* the `LBB` labels stayed when they are used
* you can easily see labels in arguments, so tracing control flow is a lot easier 
* assembly is packed (which I prefer)

<details>
<summary> comparison </summary>

Before:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/16103364/202828037-bf0601df-9a40-4787-84c3-0518f6baed24.png">

After:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/16103364/202828073-3fbe5105-5eb7-4519-bfe0-2e462bd03ad1.png">

After (if packing is dropped)
<img width="522" alt="image" src="https://user-images.githubusercontent.com/16103364/202828155-d30db186-cdd7-41f7-b01d-a6cc8267f9b2.png">

</details>