### PR TITLE
Prepare to release 0.2.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.8] - 2023-01-02
+- bump dependencies
+
 ## [0.2.7] - 2022-11-26
 - support mangled names
 - fix select-by-index


### PR DESCRIPTION
Mostly dependency bump, should improve error messages from bpaf a bit
