### PR TITLE
Release 0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.2.11] - 2023-01-11
+- fix filtering by index and name at the same time
+- --test, --bench, etc can be used without argument to list available items
+thanks to @danielparks
+- bump deps
+
 ## [0.2.10] - 2023-01-09
 - support for nightly -Z asm-comments
 


### PR DESCRIPTION
- fix filtering by index and name at the same time
- --test, --bench, etc can be used without argument to list available items
thanks to @danielparks
- bump deps