### PR TITLE
Add --llvm-input and -C flags

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
 
+      - name: Native version of cargo-show-asm (LLVM Input)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main
+
       - name: Native version of cargo-show-asm (MIR)
         run: cargo run -- --manifest-path sample/Cargo.toml --mir "main()"
 
@@ -99,6 +102,9 @@ jobs:
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
 
+      - name: Native version of cargo-show-asm (LLVM Input)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main
+
       - name: Native version of cargo-show-asm (MIR)
         run: cargo run -- --manifest-path sample/Cargo.toml --mir "main()"
 
@@ -151,6 +157,9 @@ jobs:
 
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
+
+      - name: Native version of cargo-show-asm (LLVM Input)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main
 
       - name: Native version of cargo-show-asm (MIR)
         run: cargo run -- --manifest-path sample/Cargo.toml --mir "main()"

--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -16,6 +16,9 @@ impl BlockRngCore for MyRngCore {
 
 impl SeedableRng for MyRngCore {
     type Seed = [u8; 32];
+
+    // Will appear in --llvm-input (before LLVM passes), but not in --llvm (after LLVM passes).
+    #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         Self(seed)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,11 @@ fn spawn_cargo(
     cmd.arg("--");
 
     // Rustc flags.
-    // We care about asm.
-    cmd.args(["--emit", syntax.emit()])
+    cmd
+        // Start with the user-supplied codegen flags, which we might need to override.
+        .args(cargo.codegen.iter().flat_map(|c| ["-C", c]))
+        // Next, we care about asm/wasm/llvm-ir/llvm-mac.
+        .args(["--emit", syntax.emit()])
         // So only one file gets created.
         .arg("-Ccodegen-units=1")
         // Debug info is needed to map to rust source.

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,9 @@ fn main() -> anyhow::Result<()> {
             &opts.cargo.target,
             &opts.target_cpu,
         ),
-        Syntax::Llvm => llvm::dump_function(opts.to_dump, &asm_path, &opts.format),
+        Syntax::Llvm | Syntax::LlvmInput => {
+            llvm::dump_function(opts.to_dump, &asm_path, &opts.format)
+        }
         Syntax::Mir => mir::dump_function(opts.to_dump, &asm_path, &opts.format),
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -229,6 +229,8 @@ pub enum Syntax {
     Att,
     /// Show llvm-ir
     Llvm,
+    /// Show llvm-ir before any LLVM passes
+    LlvmInput,
     /// Show MIR
     Mir,
     /// Show WASM, needs wasm32-unknown-unknown target installed
@@ -246,6 +248,7 @@ impl Syntax {
         match self {
             Self::Intel | Self::McaIntel => Some("llvm-args=-x86-asm-syntax=intel"),
             Self::Att | Self::McaAtt => Some("llvm-args=-x86-asm-syntax=att"),
+            Self::LlvmInput => Some("no-prepopulate-passes"),
             Self::Wasm | Self::Mir | Self::Llvm => None,
         }
     }
@@ -254,7 +257,7 @@ impl Syntax {
     pub fn emit(&self) -> &str {
         match self {
             Self::Intel | Self::Att | Self::Wasm | Self::McaIntel | Self::McaAtt => "asm",
-            Self::Llvm => "llvm-ir",
+            Self::Llvm | Self::LlvmInput => "llvm-ir",
             Self::Mir => "mir",
         }
     }
@@ -263,7 +266,7 @@ impl Syntax {
     pub fn ext(&self) -> &str {
         match self {
             Self::Intel | Self::McaAtt | Self::McaIntel | Self::Att | Self::Wasm => "s",
-            Self::Llvm => "ll",
+            Self::Llvm | Self::LlvmInput => "ll",
             Self::Mir => "mir",
         }
     }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -98,9 +98,9 @@ pub struct Cargo {
     /// Codegen flags to rustc, see 'rustc -C help' for details
     #[bpaf(short('C'), argument("FLAG"))]
     pub codegen: Vec<String>,
-    #[bpaf(short('Z'), argument("FLAG"))]
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     // OsString would be better but MetadataCommand takes a vector of strings...
+    #[bpaf(short('Z'), argument("FLAG"))]
     pub unstable: Vec<String>,
 }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -95,6 +95,9 @@ pub struct Cargo {
     /// Build for the target triple
     #[bpaf(argument("TRIPLE"))]
     pub target: Option<String>,
+    /// Codegen flags to rustc, see 'rustc -C help' for details
+    #[bpaf(short('C'), argument("FLAG"))]
+    pub codegen: Vec<String>,
     #[bpaf(short('Z'), argument("FLAG"))]
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     // OsString would be better but MetadataCommand takes a vector of strings...


### PR DESCRIPTION
Fixes: #142.

Additionally, this includes one style-only fix:

- consistently place the bpaf attribute for `unstable` before the doc comment.