### PR TITLE
only add debuginfo=2 when generating asm/wasm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,10 +100,17 @@ fn spawn_cargo(
     cmd.args(["--emit", syntax.emit()])
         // So only one file gets created.
         .arg("-Ccodegen-units=1")
-        // Debug info is needed to map to rust source.
-        .arg("-Cdebuginfo=2")
         .args(syntax.format().iter().flat_map(|s| ["-C", s]))
         .args(target_cpu.iter().map(|cpu| format!("-Ctarget-cpu={cpu}")));
+
+    // Debug info is needed to detect function boundaries in asm (Windows/Mac), and to map asm/wasm
+    // output to rust source.
+    if matches!(
+        syntax,
+        opts::Syntax::Intel | opts::Syntax::Att | opts::Syntax::Wasm
+    ) {
+        cmd.arg("-Cdebuginfo=2");
+    }
 
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())


### PR DESCRIPTION
The primary purpose of setting debuginfo=2 is to map back from ASM/WASM output to rust source. That's not necessary for LLVM IR output, or MCA, and LLVM IR gets substantially cleaner *without* debuginfo.

However, debuginfo=2 is also (currently) needed for function boundary detection on ASM output on both Windows and Mac OS.

Related: https://github.com/pacak/cargo-show-asm/pull/143#discussion_r1114247796