### PR TITLE
Release 0.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.2.14] - 2023-02-22
+- Allow to pass -C flags directly to rustc
+- --llvm-input to show llvm-ir before any LLVM passes
+- Only generate debug info for LLVM resulting in cleaner
+Thanks to @jonasmalacofilho
+
 ## [0.2.13] - 2023-02-03
 - support cdylib crates
 - bump deps

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -25,7 +25,11 @@ pub fn parse_file(input: &str) -> anyhow::Result<Vec<Statement>> {
             if leftovers.len() < 1000 {
                 anyhow::bail!("Didn't consume everything, leftovers: {leftovers:?}")
             } else {
-                let head = &leftovers[..leftovers.char_indices().nth(200).unwrap().0];
+                let head = &leftovers[..leftovers
+                    .char_indices()
+                    .nth(200)
+                    .expect("Shouldn't have that much unicode here...")
+                    .0];
                 anyhow::bail!("Didn't consume everything, leftovers prefix: {head:?}");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,13 @@ pub fn get_dump_range(
     items: BTreeMap<Item, Range<usize>>,
 ) -> Option<Range<usize>> {
     if items.len() == 1 {
-        return Some(items.into_iter().next().unwrap().1);
+        return Some(
+            items
+                .into_iter()
+                .next()
+                .expect("We just checked there's one item present")
+                .1,
+        );
     }
     match goal {
         // to dump everything just return an empty range

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -57,6 +57,8 @@ fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>> {
             }
         } else if line == "}" {
             if let Some(mut cur) = current_item.take() {
+                // go home clippy, you're drunk
+                #[allow(clippy::range_plus_one)]
                 let range = cur.len..ix + 1;
                 cur.len = range.len();
                 res.insert(cur, range);

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,13 +106,14 @@ fn spawn_cargo(
         .args(syntax.format().iter().flat_map(|s| ["-C", s]))
         .args(target_cpu.iter().map(|cpu| format!("-Ctarget-cpu={cpu}")));
 
-    // Debug info is needed to detect function boundaries in asm (Windows/Mac), and to map asm/wasm
-    // output to rust source.
-    if matches!(
-        syntax,
-        opts::Syntax::Intel | opts::Syntax::Att | opts::Syntax::Wasm
-    ) {
-        cmd.arg("-Cdebuginfo=2");
+    {
+        #[allow(clippy::enum_glob_use)]
+        use opts::Syntax::*;
+        // Debug info is needed to detect function boundaries in asm (Windows/Mac), and to map asm/wasm
+        // output to rust source.
+        if matches!(syntax, Intel | Att | Wasm | McaAtt | McaIntel) {
+            cmd.arg("-Cdebuginfo=2");
+        }
     }
 
     cmd.stdin(Stdio::null())

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -9,6 +9,10 @@ use crate::{
     opts::{Format, ToDump},
 };
 
+/// dump mca analysis
+///
+/// # Errors
+/// Clippy, why do you care?
 pub fn dump_function(
     goal: ToDump,
     path: &Path,
@@ -55,9 +59,9 @@ pub fn dump_function(
         }
     };
 
-    let mut i = mca.stdin.take().unwrap();
-    let o = mca.stdout.take().unwrap();
-    let e = mca.stderr.take().unwrap();
+    let mut i = mca.stdin.take().expect("Stdin should be piped");
+    let o = mca.stdout.take().expect("Stdout should be piped");
+    let e = mca.stderr.take().expect("Stderr should be piped");
 
     if mca_intel {
         writeln!(i, ".intel_syntax")?;

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -19,6 +19,8 @@ fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>> {
             }
         } else if line == "}" {
             if let Some(mut cur) = current_item.take() {
+                // go home clippy, you're drunk
+                #[allow(clippy::range_plus_one)]
                 let range = cur.len..ix + 1;
                 cur.len = range.len();
                 res.insert(cur, range);
@@ -57,6 +59,10 @@ fn dump_range(_fmt: &Format, strings: &[&str]) {
     }
 }
 
+/// dump mir code
+///
+/// # Errors
+/// Reports file IO errors
 pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<()> {
     let lines = CachedLines::without_ending(std::fs::read_to_string(path)?);
     let items = find_items(&lines);


### PR DESCRIPTION
- Allow to pass -C flags directly to rustc
- --llvm-input to show llvm-ir before any LLVM passes
- Only generate debug info for LLVM resulting in cleaner
Thanks to @jonasmalacofilho
- clippy things
- dependencies