### PR TITLE
Release 0.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bpaf"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423bafba382cc2c561f486bfcae41c6692833eaff0a631d10c37a9489ccd3783"
+checksum = "7ae5e130595d17ed4f7061317c2792ba94dc7754de93012c6d4c7191eb5d6c4b"
 dependencies = [
  "bpaf_derive",
  "owo-colors",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf_derive"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9ee23ce08bc40839a8153f4b873fcfa08405221ed2cd9a4968d1a94ad83234"
+checksum = "29a7fca07923e14266ed2107f9fa592a6d4895afe2e10242ffeeda56f6009314"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ supports-color = "2.0"
 
 [features]
 bright-color = ["bpaf/bright-color"]
+default = ["dull-color"]
 dull-color = ["bpaf/dull-color"]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bpaf = { version = "0.7.10", features = ["bpaf_derive", "autocomplete"] }
+bpaf = { version = "0.8.0", features = ["bpaf_derive", "autocomplete"] }
 cargo_metadata = "0.15.4"
 line-span = "0.1"
 nom = "7"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.2.18] - 2023-05-11
+- you can also specify default profile using `CARGO_SHOW_ASM_PROFILE` env variable
+- bump bpaf to 0.8.0, add dull colors by default
+
 ## [0.2.17] - 2023-04-11
 - look harder for source code, don't panic if it can't be found
 - bump deps

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -161,8 +161,8 @@ pub enum CompileMode {
     /// Compile in dev mode
     Dev,
     Custom(
-        /// Build for this specific profile
-        #[bpaf(long("profile"), argument("PROFILE"))]
+        /// Build for this specific profile, you can also use `dev` and `release` here
+        #[bpaf(env("CARGO_SHOW_ASM_PROFILE"), long("profile"), argument("PROFILE"))]
         String,
     ),
 }


### PR DESCRIPTION
- you can also specify default profile using `CARGO_SHOW_ASM_PROFILE` env variable
- bump bpaf to 0.8.0, add dull colors by default

Helps with #163 