### PR TITLE
Release 0.2.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bpaf"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72974597bfc83173d714c0fc785a8ab64ca0f0896cb72b05f2f4c5e682543871"
+checksum = "affa4185035a12636b90d7064d64fff3cca6ff5a2f65c3325a7eef0da2f272bb"
 dependencies = [
  "bpaf_derive",
  "owo-colors",
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b7be5dcfd7bb931b9932e689c69a9b9f50a46cf0b588c90ed73ec28e8e0bf4"
+checksum = "ac88f5e10b620a207805c5a6f538a7777dc55e5469bbc0eec27e2bf75d5ee0f6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bpaf = { version = "0.9.1", features = ["bpaf_derive", "autocomplete"] }
+bpaf = { version = "0.9.2", features = ["bpaf_derive", "autocomplete"] }
 cargo_metadata = "0.15.4"
 line-span = "0.1"
 nom = "7"
@@ -23,6 +23,10 @@ regex = "1"
 rustc-demangle = "0.1"
 same-file = "1.0.6"
 supports-color = "2.0"
+
+
+[dev-dependencies]
+bpaf = { version = "0.9.2", features = ["bpaf_derive", "autocomplete", "docgen"] }
 
 [features]
 bright-color = ["bpaf/bright-color"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.2.20] - 2023-06-17
+- workaround for fancier debuginfo not supported by cargo-metadata
+- usage in README is now generated in markdown
+
 ## [0.2.19] - 2023-06-05
 - bump bpaf to 0.9.1, usage in README is now generated
 - bump deps

--- a/README.md
+++ b/README.md
@@ -26,123 +26,152 @@ $ cargo install cargo-show-asm
   - Wasm code
   - llvm-mca analysis
 
-# Usage:
+# cargo asm
 
-<div class="bpaf-doc">
-# cargo asm<br>
-<p>Show the code rustc generates for any function</p><p><b>Usage</b>: <tt><b>cargo asm</b></tt> [<tt><b>-p</b></tt>=<tt><i>SPEC</i></tt>] [<tt><i>ARTIFACT</i></tt>] [<tt><b>-M</b></tt>=<tt><i>ARG</i></tt>]... [<tt><i>TARGET-CPU</i></tt>] [<tt><b>--rust</b></tt>] [<tt><b>--simplify</b></tt>] [<tt><i>OUTPUT-FORMAT</i></tt>] [<tt><b>--everything</b></tt> | <tt><i>FUNCTION</i></tt> [<tt><i>INDEX</i></tt>]]</p><p>Usage:<br>
- 1. Focus on a single assembly producing target:<br>
-    % cargo asm -p isin --lib   # here we are targeting lib in isin crate<br>
- 2. Narrow down a function:<br>
-    % cargo asm -p isin --lib from_ # here "from_" is part of the function you are interested intel<br>
- 3. Get the full results:<br>
-    % cargo asm -p isin --lib isin::base36::from_alphanum</p><p><div>
-<b>Pick artifact for analysis:</b></div><dl><dt><tt><b>    --lib</b></tt></dt>
-<dd>Show results from library code</dd>
-<dt><tt><b>    --test</b></tt>=<tt><i>TEST</i></tt></dt>
-<dd>Show results from an integration test</dd>
-<dt><tt><b>    --bench</b></tt>=<tt><i>BENCH</i></tt></dt>
-<dd>Show results from a benchmark</dd>
-<dt><tt><b>    --example</b></tt>=<tt><i>EXAMPLE</i></tt></dt>
-<dd>Show results from an example</dd>
-<dt><tt><b>    --bin</b></tt>=<tt><i>BIN</i></tt></dt>
-<dd>Show results from a binary</dd>
-</dl>
-</p><p><div>
-<b>Cargo options</b></div><dl><dt><tt><b>    --manifest-path</b></tt>=<tt><i>PATH</i></tt></dt>
-<dd>Path to Cargo.toml, defaults to one in current folder</dd>
-<dt><tt><b>    --target-dir</b></tt>=<tt><i>DIR</i></tt></dt>
-<dd>Use custom target directory for generated artifacts, create if missing</dd>
-<dt></dt>
-<dd>Uses environment variable <tt><b>CARGO_TARGET_DIR</b></tt></dd>
-<dt><tt><b>    --dry</b></tt></dt>
-<dd>Produce a build plan instead of actually building</dd>
-<dt><tt><b>    --frozen</b></tt></dt>
-<dd>Requires Cargo.lock and cache are up to date</dd>
-<dt><tt><b>    --locked</b></tt></dt>
-<dd>Requires Cargo.lock is up to date</dd>
-<dt><tt><b>    --offline</b></tt></dt>
-<dd>Run without accessing the network</dd>
-<dt><tt><b>    --no-default-features</b></tt></dt>
-<dd>Do not activate `default` feature</dd>
-<dt><tt><b>    --all-features</b></tt></dt>
-<dd>Activate all available features</dd>
-<dt><tt><b>    --features</b></tt>=<tt><i>FEATURE</i></tt></dt>
-<dd>A feature to activate, can be used multiple times</dd>
-<dt><tt><b>    --release</b></tt></dt>
-<dd>Compile in release mode (default)</dd>
-<dt><tt><b>    --dev</b></tt></dt>
-<dd>Compile in dev mode</dd>
-<dt><tt><b>    --profile</b></tt>=<tt><i>PROFILE</i></tt></dt>
-<dd>Build for this specific profile, you can also use `dev` and `release` here</dd>
-<dt></dt>
-<dd>Uses environment variable <tt><b>CARGO_SHOW_ASM_PROFILE</b></tt></dd>
-<dt><tt><b>    --target</b></tt>=<tt><i>TRIPLE</i></tt></dt>
-<dd>Build for the target triple</dd>
-<dt><tt><b>-C</b></tt>=<tt><i>FLAG</i></tt></dt>
-<dd>Codegen flags to rustc, see 'rustc -C help' for details</dd>
-<dt><tt><b>-Z</b></tt>=<tt><i>FLAG</i></tt></dt>
-<dd>Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details</dd>
-</dl>
-</p><p><div>
-<b>Postprocessing options:</b></div><dl><dt><tt><b>    --rust</b></tt></dt>
-<dd>Print interleaved Rust code</dd>
-<dt><tt><b>    --color</b></tt></dt>
-<dd>Enable color highlighting</dd>
-<dt><tt><b>    --no-color</b></tt></dt>
-<dd>Disable color highlighting</dd>
-<dt><tt><b>    --full-name</b></tt></dt>
-<dd>Include full demangled name instead of just prefix</dd>
-<dt><tt><b>    --keep-labels</b></tt></dt>
-<dd>Keep all the original labels</dd>
-<dt><tt><b>-v</b></tt>, <tt><b>--verbose</b></tt></dt>
-<dd>more verbose output, can be specified multiple times</dd>
-<dt><tt><b>    --simplify</b></tt></dt>
-<dd>Try to strip some of the non-assembly instruction information</dd>
-</dl>
-</p><p><div>
-<b>Pick output format:</b></div><dl><dt><tt><b>    --intel</b></tt></dt>
-<dd>Show assembly using Intel style</dd>
-<dt><tt><b>    --att</b></tt></dt>
-<dd>Show assembly using AT&T style</dd>
-<dt><tt><b>    --llvm</b></tt></dt>
-<dd>Show llvm-ir</dd>
-<dt><tt><b>    --llvm-input</b></tt></dt>
-<dd>Show llvm-ir before any LLVM passes</dd>
-<dt><tt><b>    --mir</b></tt></dt>
-<dd>Show MIR</dd>
-<dt><tt><b>    --wasm</b></tt></dt>
-<dd>Show WASM, needs wasm32-unknown-unknown target installed</dd>
-<dt><tt><b>    --mca-intel</b></tt></dt>
-<dd>Show llvm-mca analysis, Intel style asm</dd>
-<dt><tt><b>    --mca-att</b></tt></dt>
-<dd>Show llvm-mca analysis, AT&T style asm</dd>
-</dl>
-</p><p><div>
-<b>Pick item to display from the artifact</b></div><dl><dt><tt><b>    --everything</b></tt></dt>
-<dd>Dump the whole file</dd>
-<dt><tt><i>FUNCTION</i></tt></dt>
-<dd>Dump a function with a given name, filter functions by name</dd>
-<dt><tt><i>INDEX</i></tt></dt>
-<dd>Select specific function when there's several with the same name</dd>
-</dl>
-</p><p><div>
-<b>Available options:</b></div><dl><dt><tt><b>-p</b></tt>, <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt></dt>
-<dd>Package to use, defaults to a current one,<br>
-required for workspace projects, can also point to a dependency</dd>
-<dt><tt><b>-M</b></tt>, <tt><b>--mca-arg</b></tt>=<tt><i>ARG</i></tt></dt>
-<dd>Pass parameter to llvm-mca for mca targets</dd>
-<dt><tt><b>    --native</b></tt></dt>
-<dd>Optimize for the CPU running the compiler</dd>
-<dt><tt><b>    --target-cpu</b></tt>=<tt><i>CPU</i></tt></dt>
-<dd>Optimize code for a specific CPU, see 'rustc --print target-cpus'</dd>
-<dt><tt><b>-h</b></tt>, <tt><b>--help</b></tt></dt>
-<dd>Prints help information</dd>
-<dt><tt><b>-V</b></tt>, <tt><b>--version</b></tt></dt>
-<dd>Prints version information</dd>
-</dl>
-</p>
-</div>
+Show the code rustc generates for any function
+
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+
+ Usage:
+ 1. Focus on a single assembly producing target:
+
+  ```text
+   % cargo asm -p isin --lib   # here we are targeting lib in isin crate
+
+
+  ```
+ 2. Narrow down a function:
+
+  ```text
+   % cargo asm -p isin --lib from_ # here "from_" is part of the function you are interested intel
+
+
+  ```
+ 3. Get the full results:
+
+  ```text
+   % cargo asm -p isin --lib isin::base36::from_alphanum
+  ```
+
+
+**Pick artifact for analysis:**
+- **`    --lib`** &mdash; 
+  Show results from library code
+- **`    --test`**=_`TEST`_ &mdash; 
+  Show results from an integration test
+- **`    --bench`**=_`BENCH`_ &mdash; 
+  Show results from a benchmark
+- **`    --example`**=_`EXAMPLE`_ &mdash; 
+  Show results from an example
+- **`    --bin`**=_`BIN`_ &mdash; 
+  Show results from a binary
+
+
+
+**Cargo options**
+- **`    --manifest-path`**=_`PATH`_ &mdash; 
+  Path to Cargo.toml, defaults to one in current folder
+- **`    --target-dir`**=_`DIR`_ &mdash; 
+  Use custom target directory for generated artifacts, create if missing
+   
+  Uses environment variable **`CARGO_TARGET_DIR`**
+- **`    --dry`** &mdash; 
+  Produce a build plan instead of actually building
+- **`    --frozen`** &mdash; 
+  Requires Cargo.lock and cache are up to date
+- **`    --locked`** &mdash; 
+  Requires Cargo.lock is up to date
+- **`    --offline`** &mdash; 
+  Run without accessing the network
+- **`    --no-default-features`** &mdash; 
+  Do not activate `default` feature
+- **`    --all-features`** &mdash; 
+  Activate all available features
+- **`    --features`**=_`FEATURE`_ &mdash; 
+  A feature to activate, can be used multiple times
+- **`    --release`** &mdash; 
+  Compile in release mode (default)
+- **`    --dev`** &mdash; 
+  Compile in dev mode
+- **`    --profile`**=_`PROFILE`_ &mdash; 
+  Build for this specific profile, you can also use `dev` and `release` here
+   
+  Uses environment variable **`CARGO_SHOW_ASM_PROFILE`**
+- **`    --target`**=_`TRIPLE`_ &mdash; 
+  Build for the target triple
+- **`-C`**=_`FLAG`_ &mdash; 
+  Codegen flags to rustc, see 'rustc -C help' for details
+- **`-Z`**=_`FLAG`_ &mdash; 
+  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+
+
+
+**Postprocessing options:**
+- **`    --rust`** &mdash; 
+  Print interleaved Rust code
+- **`    --color`** &mdash; 
+  Enable color highlighting
+- **`    --no-color`** &mdash; 
+  Disable color highlighting
+- **`    --full-name`** &mdash; 
+  Include full demangled name instead of just prefix
+- **`    --keep-labels`** &mdash; 
+  Keep all the original labels
+- **`-v`**, **`--verbose`** &mdash; 
+  more verbose output, can be specified multiple times
+- **`    --simplify`** &mdash; 
+  Try to strip some of the non-assembly instruction information
+
+
+
+**Pick output format:**
+- **`    --intel`** &mdash; 
+  Show assembly using Intel style
+- **`    --att`** &mdash; 
+  Show assembly using AT&T style
+- **`    --llvm`** &mdash; 
+  Show llvm-ir
+- **`    --llvm-input`** &mdash; 
+  Show llvm-ir before any LLVM passes
+- **`    --mir`** &mdash; 
+  Show MIR
+- **`    --wasm`** &mdash; 
+  Show WASM, needs wasm32-unknown-unknown target installed
+- **`    --mca-intel`** &mdash; 
+  Show llvm-mca analysis, Intel style asm
+- **`    --mca-att`** &mdash; 
+  Show llvm-mca analysis, AT&T style asm
+
+
+
+**Pick item to display from the artifact**
+- **`    --everything`** &mdash; 
+  Dump the whole file
+- _`FUNCTION`_ &mdash; 
+  Dump a function with a given name, filter functions by name
+- _`INDEX`_ &mdash; 
+  Select specific function when there's several with the same name
+
+
+
+**Available options:**
+- **`-p`**, **`--package`**=_`SPEC`_ &mdash; 
+  Package to use, defaults to a current one,
+
+  required for workspace projects, can also point to a dependency
+- **`-M`**, **`--mca-arg`**=_`ARG`_ &mdash; 
+  Pass parameter to llvm-mca for mca targets
+- **`    --native`** &mdash; 
+  Optimize for the CPU running the compiler
+- **`    --target-cpu`**=_`CPU`_ &mdash; 
+  Optimize code for a specific CPU, see 'rustc --print target-cpus'
+- **`-h`**, **`--help`** &mdash; 
+  Prints help information
+- **`-V`**, **`--version`** &mdash; 
+  Prints version information
+
+
+
 
 You can start by running `cargo asm` with no parameters - it will suggests how to narrow the
 search scope - for workspace crates you need to specify a crate to work with, for crates

--- a/README.tpl
+++ b/README.tpl
@@ -26,11 +26,7 @@ $ cargo install cargo-show-asm
   - Wasm code
   - llvm-mca analysis
 
-# Usage:
-
-<div class="bpaf-doc">
 <USAGE>
-</div>
 
 You can start by running `cargo asm` with no parameters - it will suggests how to narrow the
 search scope - for workspace crates you need to specify a crate to work with, for crates

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -14,4 +14,8 @@ rand_core = "0.6"
 default = ["superbanana"]
 superbanana = []
 
+
+[profile.release]
+debug = "line-tables-only"
+
 [workspace]

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,25 @@ fn main() -> anyhow::Result<()> {
                 success = fin.success;
                 break;
             }
+            Message::TextLine(x) => {
+                // 1.71.1 added support for debuginfo=line-tables-only and line-directives-only
+                // cargo-metadata did not and cannot easily add this without a breaking release
+                //
+                // Since we don't really use profile info from the Artifact structure we
+                // can replace it with something it cargo-metadata can parse.
+                if !x.contains(r#""debuginfo":"line"#) {
+                    continue;
+                }
+                let x = x.replace(r#""debuginfo":"line-tables-only""#, r#""debuginfo":2"#);
+                let x = x.replace(r#""debuginfo":"line-directives-only""#, r#""debuginfo":2"#);
+                if let Some(Ok(Message::CompilerArtifact(artifact))) =
+                    Message::parse_stream(x.as_bytes()).next()
+                {
+                    if focus_artifact.matches_artifact(&artifact) {
+                        result_artifact = Some(artifact);
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ fn spawn_cargo(
         .args(["--emit", syntax.emit()])
         // So only one file gets created.
         .arg("-Ccodegen-units=1")
-        .arg("-Clto=no")
         .args(syntax.format().iter().flat_map(|s| ["-C", s]))
         .args(target_cpu.iter().map(|cpu| format!("-Ctarget-cpu={cpu}")));
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -421,7 +421,7 @@ fn write_updated(new_val: &str, path: impl AsRef<std::path::Path>) -> std::io::R
 #[cfg(unix)]
 #[test]
 fn docs_are_up_to_date() {
-    let usage = options().render_html("cargo asm");
+    let usage = options().render_markdown("cargo asm");
     let readme = std::fs::read_to_string("README.tpl").unwrap();
     let docs = readme.replacen("<USAGE>", &usage, 1);
     assert!(write_updated(&docs, "README.md").unwrap());


### PR DESCRIPTION
- workaround for lto in 1.67.1 is removed - users can pass it manually with `-Clto=no` or something
- workaround for fancier debuginfo in 1.71.0 is added - will remove it once cargo-metadata updates
- documentation is now generated in markdown

Fixes #186 
Addresses an issue in #187