### PR TITLE
Adds support for `no_mangle` in macOS

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -59,7 +59,10 @@ jobs:
         run: cargo run -- --manifest-path sample_rlib/Cargo.toml --att
 
       - name: cdylib project
-        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml add
+
+      - name: cdylib project, underscore prefix
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml _mul
 
   windows:
     runs-on: windows-latest
@@ -171,4 +174,7 @@ jobs:
         run: cargo run -- --manifest-path sample_rlib/Cargo.toml --att
 
       - name: cdylib project
-        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml add
+
+      - name: cdylib project, underscore prefix
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml _mul

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -171,4 +171,4 @@ jobs:
         run: cargo run -- --manifest-path sample_rlib/Cargo.toml --att
 
       - name: cdylib project
-        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml --everything
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml

--- a/sample_cdylib/src/lib.rs
+++ b/sample_cdylib/src/lib.rs
@@ -2,3 +2,13 @@
 pub extern "C" fn add(left: usize, right: usize) -> usize {
     left + right
 }
+
+#[no_mangle]
+pub extern "C" fn sub(left: usize, right: usize) -> usize {
+    left - right
+}
+
+#[no_mangle]
+pub extern "C" fn _mul(left: usize, right: usize) -> usize {
+    left * right
+}


### PR DESCRIPTION
Currently, `no_mangle` functions are not being found on macOS because de-mangling fails & the .text sections are a different format on macOS.

This PR adds support for finding `no_mangle` attributes in macOS using the `.globl` directive & refactors `asm::find_items` a little to reduce nesting.

Related: #137 