### PR TITLE
feat: Parameterize symbol demangling on command line.

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -43,8 +43,14 @@ jobs:
       - name: Native version of cargo-show-asm (Intel ASM) + atom
         run: cargo run -- --manifest-path sample/Cargo.toml --target-cpu atom --intel sample::main --rust
 
+      - name: Native version of cargo-show-asm with symbol mangling (Intel ASM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --intel sample::main --rust --keep-mangled
+
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
+
+      - name: Native version of cargo-show-asm with symbol mangling (LLVM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm --keep-mangled sample::main
 
       - name: Native version of cargo-show-asm (LLVM Input)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main
@@ -102,8 +108,14 @@ jobs:
       - name: Native version of cargo-show-asm (Intel ASM) + atom
         run: cargo run -- --manifest-path sample/Cargo.toml --target-cpu atom --intel sample::main --rust
 
+      - name: Native version of cargo-show-asm with symbol mangling (Intel ASM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --intel sample::main --rust --keep-mangled
+
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
+
+      - name: Native version of cargo-show-asm with symbol mangling (LLVM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm --keep-mangled sample::main
 
       - name: Native version of cargo-show-asm (LLVM Input)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main
@@ -158,8 +170,14 @@ jobs:
       - name: Native version of cargo-show-asm (Intel ASM) + atom
         run: cargo run -- --manifest-path sample/Cargo.toml --target-cpu atom --intel sample::main --rust
 
+      - name: Native version of cargo-show-asm with symbol mangling (Intel ASM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --intel sample::main --rust --keep-mangled
+
       - name: Native version of cargo-show-asm (LLVM)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm sample::main
+
+      - name: Native version of cargo-show-asm with symbol mangling (LLVM)
+        run: cargo run -- --manifest-path sample/Cargo.toml --llvm --keep-mangled sample::main
 
       - name: Native version of cargo-show-asm (LLVM Input)
         run: cargo run -- --manifest-path sample/Cargo.toml --llvm-input sample::main

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[**`--keep-mangled`** | **`--demangle`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -127,9 +127,9 @@ Show the code rustc generates for any function
   Try to strip some of the non-assembly instruction information
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
-- **`--keep-mangled`** &mdash;
+- **`    --keep-mangled`** &mdash; 
   Do not demangle symbol names
-- **`--demangle`** &mdash;
+- **`    --demangle`** &mdash; 
   Demangle symbol names (default)
 
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Show the code rustc generates for any function
   Try to strip some of the non-assembly instruction information
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
-- **--keep-mangled** &mdash;
+- **`--keep-mangled`** &mdash;
   Do not demangle symbol names
-- **--demangle** &mdash;
+- **`--demangle`** &mdash;
   Demangle symbol names (default)
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[**`--keep-mangled`** | **`--demangle`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -115,6 +115,10 @@ Show the code rustc generates for any function
   Disable color highlighting
 - **`    --full-name`** &mdash; 
   Include full demangled name instead of just prefix
+- **`    --short`** &mdash; 
+  Include demangled names without hash suffix (default)
+- **`    --keep-mangled`** &mdash; 
+  Do not demangle symbol names
 - **`-K`**, **`--keep-labels`** &mdash; 
   Keep all the original labels
 - **`-B`**, **`--keep-blanks`** &mdash; 
@@ -127,10 +131,6 @@ Show the code rustc generates for any function
   Try to strip some of the non-assembly instruction information
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
-- **`    --keep-mangled`** &mdash; 
-  Do not demangle symbol names
-- **`    --demangle`** &mdash; 
-  Demangle symbol names (default)
 
 
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Show the code rustc generates for any function
   Try to strip some of the non-assembly instruction information
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
+- **--keep-mangled** &mdash;
+  Do not demangle symbol names
+- **--demangle** &mdash;
+  Demangle symbol names (default)
 
 
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Show the code rustc generates for any function
   Disable color highlighting
 - **`    --full-name`** &mdash; 
   Include full demangled name instead of just prefix
-- **`    --short`** &mdash; 
+- **`    --short-name`** &mdash; 
   Include demangled names without hash suffix (default)
 - **`    --keep-mangled`** &mdash; 
   Do not demangle symbol names

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -275,9 +275,9 @@ pub fn dump_range(
 
             empty_line = false;
             #[allow(clippy::match_bool)]
-            match fmt.full_name {
-                true => safeprintln!("{line:#}"),
-                false => safeprintln!("{line}"),
+            match fmt.name_display {
+                crate::opts::NameDisplay::Full => safeprintln!("{line:#}"),
+                _ => safeprintln!("{line}"),
             }
         }
     }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -82,6 +82,7 @@ pub fn find_items(lines: &[Statement]) -> BTreeMap<Item, Range<usize>> {
                 let name = format!("{dem:#?}");
                 let name_entry = names.entry(name.clone()).or_insert(0);
                 item = Some(Item {
+                    mangled_name: label.id.to_owned(),
                     name,
                     hashed,
                     index: *name_entry,
@@ -156,6 +157,7 @@ fn get_item_in_section(
                 String::from(label.id)
             };
             return Some(Item {
+                mangled_name: label.id.to_owned(),
                 name: name.clone(),
                 hashed: name,
                 index: 0, // Written later in find_items

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -8,7 +8,7 @@ use crate::{
     color,
     demangle::{self, contents},
     get_dump_range,
-    opts::{Format, ToDump},
+    opts::{Format, NameDisplay, ToDump},
     safeprintln, Item,
 };
 use std::{
@@ -90,7 +90,7 @@ fn dump_range(fmt: &Format, strings: &[&str]) {
         if line.starts_with("; ") {
             safeprintln!("{}", color!(line, OwoColorize::bright_black));
         } else {
-            let line = demangle::contents(line, fmt.full_name);
+            let line = demangle::contents(line, fmt.name_display == NameDisplay::Full);
             safeprintln!("{line}");
         }
     }
@@ -168,7 +168,10 @@ pub fn collect_or_dump(
                         if seen {
                             safeprintln!("{}", color!(name, OwoColorize::cyan));
                             safeprintln!("{}", color!(attrs, OwoColorize::cyan));
-                            safeprintln!("{}", contents(&line, fmt.full_name));
+                            safeprintln!(
+                                "{}",
+                                contents(&line, fmt.name_display == NameDisplay::Full)
+                            );
                         }
                     } else {
                         state = State::Skipping;
@@ -179,7 +182,7 @@ pub fn collect_or_dump(
             }
             State::Define => {
                 if seen {
-                    safeprintln!("{}", contents(&line, fmt.full_name));
+                    safeprintln!("{}", contents(&line, fmt.name_display == NameDisplay::Full));
                 }
                 if line == "}" {
                     if let Some(mut cur) = current_item.take() {

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     demangle, esafeprintln, get_dump_range,
-    opts::{Format, ToDump},
+    opts::{Format, NameDisplay, ToDump},
     safeprintln,
 };
 
@@ -87,7 +87,7 @@ pub fn dump_function(
 
     for line in BufRead::lines(BufReader::new(o)) {
         let line = line?;
-        let line = demangle::contents(&line, fmt.full_name);
+        let line = demangle::contents(&line, fmt.name_display == NameDisplay::Full);
         safeprintln!("{line}");
     }
 

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -38,6 +38,7 @@ fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>> {
                 break;
             }
             current_item = Some(Item {
+                mangled_name: name.to_owned(),
                 name: name.to_owned(),
                 hashed: name.to_owned(),
                 index: res.len(),

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -255,6 +255,7 @@ pub enum NameDisplay {
     Full,
 
     /// Include demangled names without hash suffix (default)
+    #[bpaf(long("short-name"))]
     Short,
 
     /// Do not demangle symbol names

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -232,6 +232,10 @@ pub struct Format {
     /// Keep blank lines
     #[bpaf(short('b'), long, hide_usage)]
     pub keep_blank: bool,
+
+    /// Demangle symbols
+    #[bpaf(external)]
+    pub demangle: Demangle,
 }
 
 #[derive(Debug, Clone, Bpaf, Eq, PartialEq)]
@@ -246,6 +250,17 @@ pub enum RedundantLabels {
     /// Strip redundant labels entirely
     #[bpaf(short('R'), long("reduce-labels"))]
     Strip,
+}
+
+#[derive(Debug, Copy, Clone, Bpaf, Eq, PartialEq)]
+#[bpaf(fallback(Demangle::Yes))]
+pub enum Demangle {
+    /// Do not demangle symbol names
+    #[bpaf(long("keep-mangled"))]
+    No,
+    /// Demangle symbol names (default)
+    #[bpaf(long("demangle"))]
+    Yes,
 }
 
 #[derive(Debug, Clone, Bpaf, Eq, PartialEq, Copy)]

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -215,9 +215,8 @@ pub struct Format {
     #[bpaf(external(color_detection), hide_usage)]
     pub color: bool,
 
-    /// Include full demangled name instead of just prefix
-    #[bpaf(hide_usage)]
-    pub full_name: bool,
+    #[bpaf(hide_usage, external)]
+    pub name_display: NameDisplay,
 
     #[bpaf(external, hide_usage)]
     pub redundant_labels: RedundantLabels,
@@ -232,10 +231,6 @@ pub struct Format {
     /// Keep blank lines
     #[bpaf(short('b'), long, hide_usage)]
     pub keep_blank: bool,
-
-    /// Demangle symbols
-    #[bpaf(external)]
-    pub demangle: Demangle,
 }
 
 #[derive(Debug, Clone, Bpaf, Eq, PartialEq)]
@@ -253,14 +248,18 @@ pub enum RedundantLabels {
 }
 
 #[derive(Debug, Copy, Clone, Bpaf, Eq, PartialEq)]
-#[bpaf(fallback(Demangle::Yes))]
-pub enum Demangle {
+#[bpaf(fallback(NameDisplay::Short))]
+pub enum NameDisplay {
+    #[bpaf(long("full-name"))]
+    /// Include full demangled name instead of just prefix
+    Full,
+
+    /// Include demangled names without hash suffix (default)
+    Short,
+
     /// Do not demangle symbol names
     #[bpaf(long("keep-mangled"))]
-    No,
-    /// Demangle symbol names (default)
-    #[bpaf(long("demangle"))]
-    Yes,
+    Mangled,
 }
 
 #[derive(Debug, Clone, Bpaf, Eq, PartialEq, Copy)]


### PR DESCRIPTION
This commit adds two new switched (--keep-mangled and --demangle) where --demangle is specified by default. keep-mangled can be useful when one wants to do the demangling themselves with a different library than rustc_demangle (e.g. to analyze symbol names with [ast-demangle](https://github.com/EFanZh/ast-demangle)).