### PR TITLE
feat: Optionally leave function names in asm listings unmangled.

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -274,10 +274,10 @@ pub fn dump_range(
             }
 
             empty_line = false;
-            #[allow(clippy::match_bool)]
             match fmt.name_display {
                 crate::opts::NameDisplay::Full => safeprintln!("{line:#}"),
-                _ => safeprintln!("{line}"),
+                crate::opts::NameDisplay::Short => safeprintln!("{line}"),
+                crate::opts::NameDisplay::Mangled => safeprintln!("{line:-}"),
             }
         }
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -57,7 +57,12 @@ impl std::fmt::Display for Instruction<'_> {
             write!(f, "{}", color!(self.op, OwoColorize::bright_blue))?;
         }
         if let Some(args) = self.args {
-            let args = demangle::contents(args, f.alternate());
+            let args = if f.sign_minus() {
+                // Do not demangle
+                Cow::from(args)
+            } else {
+                demangle::contents(args, f.alternate())
+            };
             let w_label = demangle::color_local_labels(&args);
             let w_comment = demangle::color_comment(&w_label);
             write!(f, " {w_comment}")?;
@@ -78,7 +83,9 @@ impl std::fmt::Display for Statement<'_> {
                 }
             }
             Statement::Instruction(i) => {
-                if f.alternate() {
+                if f.sign_minus() {
+                    write!(f, "\t{i:-#}")
+                } else if f.alternate() {
                     write!(f, "\t{i:#}")
                 } else {
                     write!(f, "\t{i}")


### PR DESCRIPTION
This adds a new format specifier support (-) to Instruction's Display implementation.

Output of `cargo run -- --keep-mangled --lib -C symbol-mangling-version=v0  --asm 4` (shortened for brevity):
Without `--keep-mangled`:
```
	mov w0, #8
	mov w1, #24
	bl alloc::alloc::handle_alloc_error
```
With `--keep-mangled`:
```
	mov w0, #8
	mov w1, #24
	bl __ZN5alloc5alloc18handle_alloc_error17h04014ba8bc4ecf83E
```
With `--full-name`:
```
	mov w0, #8
	mov w1, #24
	bl alloc::alloc::handle_alloc_error::h04014ba8bc4ecf83
```