### PR TITLE
llvm: Improve accuracy of reported line counts by not counting blanks in

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct Item {
     pub hashed: String,
     /// sequential number of demangled name
     pub index: usize,
-    /// number of lines
+    /// number of non-blank lines
     pub len: usize,
 }
 


### PR DESCRIPTION
Previously line counts were calculated as a difference between the start and end line numbers of a function definition. This led to blank lines or lines with comments being included in the count. In order to bring the reported values closer to what cargo-llvm-lines reports, we only count non-empty lines (that aren't comments). For a medium-sized crate (that I cannot publish), this brings the sum of sizes reported by cargo-show-asm from 2591619 lines to 1577786, where the size reported by cargo-llvm-lines is 1523260. The difference can likely be explained by codegen option differences between llvm-lines and show-asm (show-asm uses single CG + it doesn't use no-prepopulate-passes like llvm-lines)