### PR TITLE
Trying to fix CI failure

### DIFF
--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -25,6 +25,7 @@ impl SeedableRng for MyRngCore {
 }
 
 #[cfg(not(feature = "superbanana"))]
+#[inline(never)]
 pub fn main() -> u32 {
     1 + 1
 }
@@ -38,6 +39,7 @@ impl Bar {
 }
 
 #[cfg(feature = "superbanana")]
+#[inline(never)]
 pub fn main() {
     let mut rng = BlockRng::<MyRngCore>::seed_from_u64(0);
     for ix in 0..10 {

--- a/sample_rlib/lib.rs
+++ b/sample_rlib/lib.rs
@@ -1,4 +1,4 @@
+#[inline(never)]
 pub fn add(a: usize, b: usize) -> usize {
     a + b
 }
-


### PR DESCRIPTION
The culprit lied in https://github.com/rust-lang/rust/pull/116505

In short, with default features turned off, main was trivial enough to
be marked as inline function automatically which then made the symbol
weak. Since nobody was referencing it, it got stripped away.

Marking main in default-features=false config as #[inline(never)] or
replacing 1 + 1 in it's body with a simple println!("foo") call (to make
the main function sophisticated enough not to be subject to the new
automatic marking as inline) makes the test pass again.