### PR TITLE
Avoid usage of bright_black color

### DIFF
--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -102,19 +102,19 @@ impl std::fmt::Display for Directive<'_> {
             Directive::Loc(l) => l.fmt(f),
             Directive::Generic(g) => g.fmt(f),
             Directive::Set(g) => {
-                f.write_str(&format!(".set {}", color!(g, OwoColorize::bright_black)))
+                f.write_str(&format!(".set {}", color!(g, OwoColorize::bright_cyan)))
             }
             Directive::SectionStart(s) => {
                 let dem = demangle::contents(s, display);
                 f.write_str(&format!(
                     "{} {}",
-                    color!(".section", OwoColorize::bright_black),
+                    color!(".section", OwoColorize::bright_red),
                     dem
                 ))
             }
             Directive::SubsectionsViaSym => f.write_str(&format!(
                 ".{}",
-                color!("subsections_via_symbols", OwoColorize::bright_black)
+                color!("subsections_via_symbols", OwoColorize::bright_red)
             )),
         }
     }
@@ -144,7 +144,7 @@ impl std::fmt::Display for GenericDirective<'_> {
             "\t.{}",
             color!(
                 demangle::contents(self.0, display),
-                OwoColorize::bright_black
+                OwoColorize::bright_magenta
             )
         )
     }
@@ -191,7 +191,7 @@ impl std::fmt::Display for Label<'_> {
             "{}:",
             color!(
                 demangle::contents(self.id, display),
-                OwoColorize::bright_black
+                OwoColorize::bright_yellow
             )
         )
     }

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -81,7 +81,7 @@ struct LabelColorizer;
 impl Replacer for LabelColorizer {
     fn replace_append(&mut self, caps: &regex::Captures<'_>, dst: &mut String) {
         use std::fmt::Write;
-        write!(dst, "{}", color!(&caps[0], OwoColorize::bright_black)).unwrap();
+        write!(dst, "{}", color!(&caps[0], OwoColorize::bright_yellow)).unwrap();
     }
 }
 

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -122,7 +122,7 @@ pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<
 fn dump_range(fmt: &Format, strings: &[&str]) {
     for line in strings {
         if line.starts_with("; ") {
-            safeprintln!("{}", color!(line, OwoColorize::bright_black));
+            safeprintln!("{}", color!(line, OwoColorize::bright_cyan));
         } else {
             let line = demangle::contents(line, fmt.name_display);
             safeprintln!("{line}");


### PR DESCRIPTION
The use of `OwoColorize::bright_black()` seem to affect a lot of users with dark color schemes as it makes parts of the output unreadable.

Avoid the explicit usage of black color and replace all occurrences with a suitable alternate color.

Fixes #170