### PR TITLE
Relese 0.2.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.27] - 2024-01-14
+- look for rustc source code in the right place, see https://github.com/pacak/cargo-show-asm/issues/238
+
 ## [0.2.26] - 2024-01-09
 - avoid using hard to see colors
 thanks to @epontan

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -300,6 +300,9 @@ pub fn dump_range(
 //    Some examples:
 //        /cargo/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/src/raw/bitmask.rs
 //        /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/src/map.rs
+// 4. rustc sources:
+//    /rustc/89e2160c4ca5808657ed55392620ed1dbbce78d1/compiler/rustc_span/src/span_encoding.rs
+//    $sysroot/lib/rustlib/rust-src/rust/compiler/rustc_span/src/span_encoding.rs
 fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
     // a real file that simply exists
     if path.exists() {
@@ -313,6 +316,20 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
         );
         std::process::exit(1);
     };
+
+    // /rustc/89e2160c4ca5808657ed55392620ed1dbbce78d1/compiler/rustc_span/src/span_encoding.rs
+    if path.starts_with("/rustc") && path.iter().any(|c| c == "compiler") {
+        let mut source = sysroot.join("lib/rustlib/rustc-src/rust");
+        for part in path.components().skip(3) {
+            source.push(part);
+        }
+
+        if source.exists() {
+            return Some(source);
+        } else {
+            no_rust_src();
+        }
+    }
 
     // rust sources, Linux style
     if path.starts_with("/rustc/") {


### PR DESCRIPTION
- look for rustc (not stdlib!) source code in the right place

Fixes https://github.com/pacak/cargo-show-asm/issues/238