### PR TITLE
Release 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -19,9 +19,9 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bpaf"
@@ -47,18 +47,18 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
  "serde",
 ]
@@ -96,43 +96,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
@@ -147,15 +130,15 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aa48fab2893d8a49caa94082ae8488f4e1050d73b367881dcd2198f4199fd8"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "line-span"
@@ -165,15 +148,15 @@ checksum = "29fc123b2f6600099ca18248f69e3ee02b09c4188c0d98e9a690d90dec3e408a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "minimal-lexical"
@@ -214,18 +197,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -267,9 +250,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags",
  "errno",
@@ -280,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -295,27 +278,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.165"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.165"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -324,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -345,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -356,18 +339,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -376,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "winapi"
@@ -398,9 +381,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -413,18 +396,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -437,42 +420,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,12 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bpaf"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19232d7d855392d993f6dabd8dea40a457a6d24ef679fe98f5edca811bb11e21"
+checksum = "edc932b40b31d9bea0196f54c5b1b721b9aff3882fc08d9fe4082970c7e94d3d"
 dependencies = [
  "bpaf_derive",
- "owo-colors 3.5.0",
+ "owo-colors",
  "supports-color",
 ]
 
@@ -73,7 +73,7 @@ dependencies = [
  "line-span",
  "nom",
  "once_cell",
- "owo-colors 4.0.0",
+ "owo-colors",
  "regex",
  "rustc-demangle",
  "same-file",
@@ -179,12 +179,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "owo-colors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-bpaf = { version = "0.9.8", features = ["bpaf_derive", "autocomplete"] }
+bpaf = { version = "0.9.9", features = ["bpaf_derive", "autocomplete"] }
 cargo_metadata = "0.18.1"
 line-span = "0.1"
 nom = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1"
 rustc-demangle = "0.1"
 same-file = "1.0.6"
 supports-color = "2.1"
-serde = "<=1.0.171"
+serde = "=1.0.195"
 
 [dev-dependencies]
 bpaf = { version = "0.9.8", features = ["bpaf_derive", "autocomplete", "docgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.2.28] - 2024-01-17
+- Add a set of options to limit rust source code to workspace, regular crates or all available
+  code:
+
+        --this-workspace      Show rust sources from current workspace only
+        --all-crates          Show rust sources from current workspace and from rust registry
+        --all-sources         Show all the rust sources including stdlib and compiler
+
+
 ## [0.2.27] - 2024-01-14
 - look for rustc source code in the right place, see https://github.com/pacak/cargo-show-asm/issues/238
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -131,6 +131,12 @@ Show the code rustc generates for any function
   Try to strip some of the non-assembly instruction information
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
+- **`    --this-workspace`** &mdash; 
+  Show rust sources from current workspace only
+- **`    --all-crates`** &mdash; 
+  Show rust sources from current workspace and from rust registry
+- **`    --all-sources`** &mdash; 
+  Show all the rust sources including stdlib and compiler
 
 
 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -208,7 +208,7 @@ pub fn dump_range(
     };
 
     let mut empty_line = false;
-    for line in stmts.iter() {
+    for line in stmts {
         if fmt.verbosity > 2 {
             safeprintln!("{line:?}");
         }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -4,7 +4,7 @@ use crate::cached_lines::CachedLines;
 use crate::demangle::LabelKind;
 use crate::{color, demangle, esafeprintln, get_dump_range, safeprintln, Item};
 // TODO, use https://sourceware.org/binutils/docs/as/index.html
-use crate::opts::{Format, NameDisplay, RedundantLabels, ToDump};
+use crate::opts::{Format, NameDisplay, RedundantLabels, SourcesFrom, ToDump};
 
 mod statements;
 
@@ -14,6 +14,8 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+
+type SourceFile<'a> = (Cow<'a, Path>, Option<(Source, CachedLines)>);
 
 pub fn parse_file(input: &str) -> anyhow::Result<Vec<Statement>> {
     // eat all statements until the eof, so we can report the proper errors on failed parse
@@ -193,7 +195,7 @@ fn used_labels<'a>(stmts: &'_ [Statement<'a>]) -> BTreeSet<&'a str> {
 }
 
 pub fn dump_range(
-    files: &BTreeMap<u64, (std::borrow::Cow<Path>, Option<CachedLines>)>,
+    files: &BTreeMap<u64, SourceFile>,
     fmt: &Format,
     stmts: &[Statement],
 ) -> anyhow::Result<()> {
@@ -223,14 +225,16 @@ pub fn dump_range(
             }
             prev_loc = *loc;
             match files.get(&loc.file) {
-                Some((fname, Some(file))) => {
-                    let rust_line = &file[loc.line as usize - 1];
-                    let pos = format!("\t\t// {} : {}", fname.display(), loc.line);
-                    safeprintln!("{}", color!(pos, OwoColorize::cyan));
-                    safeprintln!(
-                        "\t\t{}",
-                        color!(rust_line.trim_start(), OwoColorize::bright_red)
-                    );
+                Some((fname, Some((source, file)))) => {
+                    if source.show_for(fmt.sources_from) {
+                        let rust_line = &file[loc.line as usize - 1];
+                        let pos = format!("\t\t// {} : {}", fname.display(), loc.line);
+                        safeprintln!("{}", color!(pos, OwoColorize::cyan));
+                        safeprintln!(
+                            "\t\t{}",
+                            color!(rust_line.trim_start(), OwoColorize::bright_red)
+                        );
+                    }
                 }
                 Some((fname, None)) => {
                     if fmt.verbosity > 0 {
@@ -287,6 +291,30 @@ pub fn dump_range(
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+pub enum Source {
+    Crate,
+    External,
+    Stdlib,
+    Rustc,
+}
+
+impl Source {
+    fn show_for(&self, from: SourcesFrom) -> bool {
+        match self {
+            Source::Crate => true,
+            Source::External => match from {
+                SourcesFrom::ThisWorkspace => false,
+                SourcesFrom::AllCrates | SourcesFrom::AllSources => true,
+            },
+            Source::Rustc | Source::Stdlib => match from {
+                SourcesFrom::ThisWorkspace | SourcesFrom::AllCrates => false,
+                SourcesFrom::AllSources => true,
+            },
+        }
+    }
+}
+
 // DWARF information contains references to souce files
 // It can point to 3 different items:
 // 1. a real file, cargo-show-asm can just read it
@@ -303,10 +331,16 @@ pub fn dump_range(
 // 4. rustc sources:
 //    /rustc/89e2160c4ca5808657ed55392620ed1dbbce78d1/compiler/rustc_span/src/span_encoding.rs
 //    $sysroot/lib/rustlib/rust-src/rust/compiler/rustc_span/src/span_encoding.rs
-fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
+fn locate_sources(sysroot: &Path, workspace: &Path, path: &Path) -> Option<(Source, PathBuf)> {
     // a real file that simply exists
     if path.exists() {
-        return Some(path.into());
+        let source = if path.starts_with(workspace) {
+            Source::Crate
+        } else {
+            Source::External
+        };
+
+        return Some((source, path.into()));
     }
 
     let no_rust_src = || {
@@ -325,7 +359,7 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
         }
 
         if source.exists() {
-            return Some(source);
+            return Some((Source::Rustc, source));
         } else {
             no_rust_src();
         }
@@ -338,7 +372,7 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
             source.push(part);
         }
         if source.exists() {
-            return Some(source);
+            return Some((Source::Stdlib, source));
         } else {
             no_rust_src();
         }
@@ -351,7 +385,7 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
             source.push(part);
         }
         if source.exists() {
-            return Some(source);
+            return Some((Source::Stdlib, source));
         } else {
             no_rust_src();
         }
@@ -373,7 +407,7 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
             source.push(part);
         }
         if source.exists() {
-            return Some(source);
+            return Some((Source::External, source));
         } else {
             panic!(
                 "{path:?} looks like it can be a cargo registry reference but we failed to get it"
@@ -386,9 +420,10 @@ fn locate_sources(sysroot: &Path, path: &Path) -> Option<PathBuf> {
 
 fn load_rust_sources<'a>(
     sysroot: &Path,
+    workspace: &Path,
     statements: &'a [Statement],
     fmt: &Format,
-    files: &mut BTreeMap<u64, (Cow<'a, Path>, Option<CachedLines>)>,
+    files: &mut BTreeMap<u64, SourceFile<'a>>,
 ) {
     for line in statements {
         if let Statement::Directive(Directive::File(f)) = line {
@@ -398,7 +433,7 @@ fn load_rust_sources<'a>(
                     safeprintln!("Reading file #{} {}", f.index, path.display());
                 }
 
-                if let Some(filepath) = locate_sources(sysroot, &path) {
+                if let Some((source, filepath)) = locate_sources(sysroot, workspace, &path) {
                     if fmt.verbosity > 2 {
                         safeprintln!("Resolved name is {filepath:?}");
                     }
@@ -411,7 +446,7 @@ fn load_rust_sources<'a>(
                             safeprintln!("Got {} bytes", sources.len());
                         }
                         let lines = CachedLines::without_ending(sources);
-                        (path, Some(lines))
+                        (path, Some((source, lines)))
                     }
                 } else {
                     if fmt.verbosity > 0 {
@@ -428,6 +463,7 @@ fn load_rust_sources<'a>(
 pub fn dump_function(
     goal: ToDump,
     path: &Path,
+    workspace: &Path,
     sysroot: &Path,
     fmt: &Format,
 ) -> anyhow::Result<()> {
@@ -448,7 +484,7 @@ pub fn dump_function(
 
     let mut files = BTreeMap::new();
     if fmt.rust {
-        load_rust_sources(sysroot, &statements, fmt, &mut files);
+        load_rust_sources(sysroot, workspace, &statements, fmt, &mut files);
     }
 
     if let Some(range) = get_dump_range(goal, fmt, functions) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,18 +86,17 @@ pub fn suggest_name<'a>(
     items: impl IntoIterator<Item = &'a Item>,
 ) {
     let mut count = 0usize;
-    let names = items.into_iter().fold(BTreeMap::new(), |mut m, item| {
-        count += 1;
-        let entry = match name_display {
-            NameDisplay::Full => &item.hashed,
-            NameDisplay::Short => &item.name,
-            NameDisplay::Mangled => &item.mangled_name,
-        };
-        m.entry(entry)
-            .or_insert_with(Vec::new)
-            .push(item.non_blank_len);
-        m
-    });
+    let names: BTreeMap<&String, Vec<usize>> =
+        items.into_iter().fold(BTreeMap::new(), |mut m, item| {
+            count += 1;
+            let entry = match name_display {
+                NameDisplay::Full => &item.hashed,
+                NameDisplay::Short => &item.name,
+                NameDisplay::Mangled => &item.mangled_name,
+            };
+            m.entry(entry).or_default().push(item.non_blank_len);
+            m
+        });
 
     if names.is_empty() {
         if search.is_empty() {
@@ -169,7 +168,7 @@ pub fn get_dump_range(
 
             let range = if nth.is_none() && filtered.len() == 1 {
                 filtered
-                    .get(0)
+                    .first()
                     .expect("Must have one item as checked above")
                     .1
                     .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,9 +234,13 @@ fn main() -> anyhow::Result<()> {
     }
 
     match opts.syntax {
-        Syntax::Intel | Syntax::Att | Syntax::Wasm => {
-            asm::dump_function(opts.to_dump, &asm_path, &sysroot, &opts.format)
-        }
+        Syntax::Intel | Syntax::Att | Syntax::Wasm => asm::dump_function(
+            opts.to_dump,
+            &asm_path,
+            metadata.workspace_root.as_std_path(),
+            &sysroot,
+            &opts.format,
+        ),
         Syntax::McaAtt | Syntax::McaIntel => mca::dump_function(
             opts.to_dump,
             &asm_path,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -231,6 +231,20 @@ pub struct Format {
     /// Keep blank lines
     #[bpaf(short('b'), long, hide_usage)]
     pub keep_blank: bool,
+
+    #[bpaf(external)]
+    pub sources_from: SourcesFrom,
+}
+
+#[derive(Debug, Clone, Copy, Bpaf)]
+#[bpaf(fallback(SourcesFrom::AllSources))]
+pub enum SourcesFrom {
+    /// Show rust sources from current workspace only
+    ThisWorkspace,
+    /// Show rust sources from current workspace and from rust registry
+    AllCrates,
+    /// Show all the rust sources including stdlib and compiler
+    AllSources,
 }
 
 #[derive(Debug, Clone, Bpaf, Eq, PartialEq)]


### PR DESCRIPTION
- Add a set of options to limit rust source code to workspace, regular crates or all available  code:

        --this-workspace      Show rust sources from current workspace only
        --all-crates          Show rust sources from current workspace and from rust registry
        --all-sources         Show all the rust sources including stdlib and compiler

- Bump deps


Fixes #241 