### PR TITLE
Release 0.2.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.29"
+version = "0.2.30"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.30] - 2024-02-11
+- Add an option `-c` / `--context` to recursively include functions called from target as
+  additional context
 
 ## [0.2.29] - 2024-01-23
 - fix function selection by index, see https://github.com/pacak/cargo-show-asm/issues/244

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`--simplify`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`-c`**=_`COUNT`_\] \[**`--simplify`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] \[_`OUTPUT-FORMAT`_\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -109,6 +109,10 @@ Show the code rustc generates for any function
 **Postprocessing options:**
 - **`    --rust`** &mdash; 
   Print interleaved Rust code
+- **`-c`**, **`--context`**=_`COUNT`_ &mdash; 
+  Include other called functions, recursively, up to COUNT depth
+   
+  [default: 0]
 - **`    --color`** &mdash; 
   Enable color highlighting
 - **`    --no-color`** &mdash; 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,13 @@ generic parameters and if it is exported (in case of a library) and not inlined 
 binary, example, test, etc). If your function takes a generic parameter - try making a monomorphic
 wrapper around it and make it `pub` and `#[inline(never)]`.
 
+# Include related functions?
+
+So suppose you have a function `foo` that calls some other function - `bar`. With `--context N`
+or it's short variant `-c N` you can ask cargo-show-asm to include body of bar to the input.
+This is done recursively up to N steps. See https://github.com/pacak/cargo-show-asm/issues/247
+
+
 # What about `cargo-asm`?
 
 `cargo-asm` is not maintained: <https://github.com/gnzlbg/cargo-asm/issues/244>. This crate is a reimplementation which addresses a number of its shortcomings, including:

--- a/README.tpl
+++ b/README.tpl
@@ -83,6 +83,13 @@ generic parameters and if it is exported (in case of a library) and not inlined 
 binary, example, test, etc). If your function takes a generic parameter - try making a monomorphic
 wrapper around it and make it `pub` and `#[inline(never)]`.
 
+# Include related functions?
+
+So suppose you have a function `foo` that calls some other function - `bar`. With `--context N`
+or it's short variant `-c N` you can ask cargo-show-asm to include body of bar to the input.
+This is done recursively up to N steps. See https://github.com/pacak/cargo-show-asm/issues/247
+
+
 # What about `cargo-asm`?
 
 `cargo-asm` is not maintained: <https://github.com/gnzlbg/cargo-asm/issues/244>. This crate is a reimplementation which addresses a number of its shortcomings, including:

--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_macros)]
+
 use rand_core::block::{BlockRng, BlockRngCore};
 use rand_core::{RngCore, SeedableRng};
 

--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -57,6 +57,13 @@ pub fn main() {
     for x in set.iter() {
         println!("{}", x);
     }
+
+    println!("Total: {}", get_length(set));
+}
+
+#[inline(never)]
+fn get_length<T>(it: hashbrown::HashSet<T>) -> usize {
+    it.len()
 }
 
 pub fn okay() {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -487,7 +487,7 @@ pub fn dump_function(
         load_rust_sources(sysroot, workspace, &statements, fmt, &mut files);
     }
 
-    if let Some(range) = get_dump_range(goal, fmt, functions) {
+    if let Some(range) = get_dump_range(goal, fmt, &functions) {
         dump_range(&files, fmt, &statements[range])?;
     } else {
         if fmt.verbosity > 0 {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -2,7 +2,9 @@
 use crate::asm::statements::{GenericDirective, Label};
 use crate::cached_lines::CachedLines;
 use crate::demangle::LabelKind;
-use crate::{color, demangle, esafeprintln, get_dump_range, safeprintln, Item};
+use crate::{
+    color, demangle, esafeprintln, get_context_for, get_dump_range, safeprintln, Item, RawLines,
+};
 // TODO, use https://sourceware.org/binutils/docs/as/index.html
 use crate::opts::{Format, NameDisplay, RedundantLabels, SourcesFrom, ToDump};
 
@@ -459,6 +461,15 @@ fn load_rust_sources<'a>(
     }
 }
 
+impl RawLines for &[Statement<'_>] {
+    fn lines(&self, range: Range<usize>) -> impl Iterator<Item = &str> {
+        self[range].iter().flat_map(|s| match s {
+            Statement::Instruction(i) => i.args,
+            _ => None,
+        })
+    }
+}
+
 /// try to print `goal` from `path`, collect available items otherwise
 pub fn dump_function(
     goal: ToDump,
@@ -488,7 +499,17 @@ pub fn dump_function(
     }
 
     if let Some(range) = get_dump_range(goal, fmt, &functions) {
+        let context = get_context_for(fmt.context, &statements[..], range.clone(), &functions);
         dump_range(&files, fmt, &statements[range])?;
+        if !context.is_empty() {
+            safeprintln!(
+                "\n\n======================= Additional context ========================="
+            );
+            for range in context {
+                safeprintln!("\n");
+                dump_range(&files, fmt, &statements[range])?;
+            }
+        }
     } else {
         if fmt.verbosity > 0 {
             safeprintln!("Going to print the whole file");

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -130,6 +130,11 @@ pub fn contents(input: &str, display: NameDisplay) -> Cow<'_, str> {
     GLOBAL_LABELS.replace_all(input, Demangler { display })
 }
 
+#[must_use]
+pub fn global_reference(input: &str) -> Option<&str> {
+    GLOBAL_LABELS.find(input).map(|m| m.as_str())
+}
+
 #[cfg(test)]
 mod test {
     use owo_colors::set_override;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,15 +135,15 @@ pub fn suggest_name<'a>(
 pub fn get_dump_range(
     goal: ToDump,
     fmt: &Format,
-    items: BTreeMap<Item, Range<usize>>,
+    items: &BTreeMap<Item, Range<usize>>,
 ) -> Option<Range<usize>> {
     if items.len() == 1 {
         return Some(
             items
-                .into_iter()
+                .values()
                 .next()
-                .expect("We just checked there's one item present")
-                .1,
+                .cloned()
+                .expect("We just checked there's one item present"),
         );
     }
     match goal {
@@ -193,8 +193,8 @@ pub fn get_dump_range(
 
         // Unspecified, so print suggestions and exit
         ToDump::Unspecified => {
-            let items = items.into_keys().collect::<Vec<_>>();
-            suggest_name("", &fmt.name_display, &items);
+            let items = items.keys();
+            suggest_name("", &fmt.name_display, items);
             unreachable!("suggest_name exits");
         }
     }

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -112,7 +112,7 @@ pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<
     let lines = CachedLines::without_ending(contents);
     let items = find_items(&lines);
     let strs = lines.iter().collect::<Vec<_>>();
-    match get_dump_range(goal, fmt, items) {
+    match get_dump_range(goal, fmt, &items) {
         Some(range) => dump_range(fmt, &strs[range]),
         None => dump_range(fmt, &strs),
     };

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -7,7 +7,7 @@ use crate::{
     cached_lines::CachedLines,
     color,
     demangle::{self, contents},
-    get_dump_range,
+    get_context_for, get_dump_range,
     opts::{Format, ToDump},
     safeprintln, Item,
 };
@@ -113,7 +113,19 @@ pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<
     let items = find_items(&lines);
     let strs = lines.iter().collect::<Vec<_>>();
     match get_dump_range(goal, fmt, &items) {
-        Some(range) => dump_range(fmt, &strs[range]),
+        Some(range) => {
+            let context = get_context_for(fmt.context, &strs[..], range.clone(), &items);
+            dump_range(fmt, &strs[range]);
+            if !context.is_empty() {
+                safeprintln!(
+                    "\n\n======================= Additional context ========================="
+                );
+                for range in context {
+                    safeprintln!("\n");
+                    dump_range(fmt, &strs[range]);
+                }
+            }
+        }
         None => dump_range(fmt, &strs),
     };
     Ok(())

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -34,7 +34,7 @@ pub fn dump_function(
 
     let lines = contents.lines().collect::<Vec<_>>();
 
-    let lines = if let Some(range) = get_dump_range(goal, fmt, functions) {
+    let lines = if let Some(range) = get_dump_range(goal, fmt, &functions) {
         &lines[range]
     } else {
         if fmt.verbosity > 0 {

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -72,7 +72,7 @@ pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<
     let lines = CachedLines::without_ending(contents);
     let items = find_items(&lines);
     let strs = lines.iter().collect::<Vec<_>>();
-    match get_dump_range(goal, fmt, items) {
+    match get_dump_range(goal, fmt, &items) {
         Some(range) => dump_range(fmt, &strs[range]),
         None => dump_range(fmt, &strs),
     };

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -1,6 +1,6 @@
 use crate::{
     cached_lines::CachedLines,
-    color, get_dump_range,
+    color, get_context_for, get_dump_range,
     opts::{Format, ToDump},
     safeprintln, Item,
 };
@@ -73,7 +73,20 @@ pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<
     let items = find_items(&lines);
     let strs = lines.iter().collect::<Vec<_>>();
     match get_dump_range(goal, fmt, &items) {
-        Some(range) => dump_range(fmt, &strs[range]),
+        Some(range) => {
+            let context = get_context_for(fmt.context, &strs[..], range.clone(), &items);
+            dump_range(fmt, &strs[range]);
+
+            if !context.is_empty() {
+                safeprintln!(
+                    "\n\n======================= Additional context ========================="
+                );
+                for range in context {
+                    safeprintln!("\n");
+                    dump_range(fmt, &strs[range]);
+                }
+            }
+        }
         None => dump_range(fmt, &strs),
     };
     Ok(())

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -212,6 +212,10 @@ pub struct Format {
     /// Print interleaved Rust code
     pub rust: bool,
 
+    /// Include other called functions, recursively, up to COUNT depth
+    #[bpaf(short, long, argument("COUNT"), fallback(0), display_fallback)]
+    pub context: usize,
+
     #[bpaf(external(color_detection), hide_usage)]
     pub color: bool,
 


### PR DESCRIPTION
- `cargo asm --context 1 foo` will print function `foo` as well as all the local functions `foo` calls. fixes #247 
- bump deps (supports-color is used twice for now)