### PR TITLE
Some minor linting, spelling, and code de-dup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "cargo-show-asm"
 version = "0.2.30"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
-categories = ["development-tools::cargo-plugins", "development-tools::debugging" ]
+categories = ["development-tools::cargo-plugins", "development-tools::debugging"]
 keywords = ["assembly", "plugins", "cargo"]
 repository = "https://github.com/pacak/cargo-show-asm"
 homepage = "https://github.com/pacak/cargo-show-asm"
-authors = [ "Michael Baykov <manpacket@gmail.com>" ]
+authors = ["Michael Baykov <manpacket@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,7 +39,7 @@ thanks to @osiewicz
   with `-B` option
 
 ## [0.2.22] - 2023-10-10
-- better support for no_mangle in MacOS
+- better support for no_mangle in macOS
 - ignore empty source files - seen them on Windows
 - bump a bunch of deps
 - add license files
@@ -86,7 +86,7 @@ Thanks to @jonasmalacofilho
 
 ## [0.2.11] - 2023-01-11
 - fix filtering by index and name at the same time
-- --test, --bench, etc can be used without argument to list available items
+- --test, --bench, etc. can be used without argument to list available items
 thanks to @danielparks
 - bump deps
 
@@ -131,7 +131,7 @@ Thanks to @RustyYato
 - fix `--color` and `--no-color`, regression since 0.2.0
 
 ## [0.2.1] - 2022-10-29
-- number of MacOS specific bugfixes
+- number of macOS specific bugfixes
 - update deps
 - more detailed output with verbosity flags
 
@@ -177,7 +177,7 @@ Thanks to @elichai
 ## [0.1.17] - 2022-09-12
 - fix typo in default features
 Thanks to @mooli
-- fix more crosscompilation issues
+- fix more cross-compilation issues
 Thanks to @WIgor
 
 ## [0.1.16] - 2022-09-03
@@ -186,7 +186,7 @@ Thanks to @WIgor
 Thanks to @yotamofek
 
 ## [0.1.15] - 2022-08-23
-- Update bpaf to 0.5.2, should start give more user fiendly suggestions
+- Update bpaf to 0.5.2, should start give more user friendly suggestions
 
 ## [0.1.14] - 2022-08-20
 - Also accept target dir from `env:CARGO_TARGET_DIR`
@@ -198,7 +198,7 @@ Thanks to @yotamofek
 - Dump single match as is
 
 ## [0.1.11] - 2022-07-23
-- Improved crosscompilation support
+- Improved cross-compilation support
 
 ## [0.1.10] - 2022-07-05
 - Upgrade cargo dependency

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ cargo install cargo-show-asm
 
 - Platform support:
 
-  - OS: Linux and MacOS. Limited support for Windows
+  - OS: Linux and macOS. Limited support for Windows
   - Rust: nightly and stable.
   - Architectures: `x86`, `x86_64`, `aarch64`, etc.
   - Cross-compilation support.
@@ -78,9 +78,9 @@ Show the code rustc generates for any function
 - **`    --dry`** &mdash; 
   Produce a build plan instead of actually building
 - **`    --frozen`** &mdash; 
-  Requires Cargo.lock and cache are up to date
+  Requires `Cargo.lock` and cache to be up-to-date
 - **`    --locked`** &mdash; 
-  Requires Cargo.lock is up to date
+  Requires `Cargo.lock` to be up-to-date
 - **`    --offline`** &mdash; 
   Run without accessing the network
 - **`    --no-default-features`** &mdash; 
@@ -193,7 +193,7 @@ Show the code rustc generates for any function
 
 
 
-You can start by running `cargo asm` with no parameters - it will suggests how to narrow the
+You can start by running `cargo asm` with no parameters - it will suggest how to narrow the
 search scope - for workspace crates you need to specify a crate to work with, for crates
 defining several targets (lib, binaries, examples) you need to specify exactly which target to
 use. In a workspace `cargo asm` lists only workspace members as suggestions but any crate from
@@ -234,7 +234,7 @@ $ cargo asm --lib --full-name
 $ cargo asm --lib "once_cell::imp::OnceCell<T>::initialize::h9c5c7d5bd745000b"
 ```
 
-`cargo-show-asm` comes with a built in search function. Just pass partial name
+`cargo-show-asm` comes with a built-in search function. Just pass partial name
 instead of a full one and only matching functions will be listed
 
 ```console
@@ -245,7 +245,7 @@ $ cargo asm --lib Debug
 
 `rustc` will only generate the code for your function if it knows what type it is, including
 generic parameters and if it is exported (in case of a library) and not inlined (in case of a
-binary, example, test, etc). If your function takes a generic parameter - try making a monomorphic
+binary, example, test, etc.). If your function takes a generic parameter - try making a monomorphic
 wrapper around it and make it `pub` and `#[inline(never)]`.
 
 # Include related functions?
@@ -261,7 +261,7 @@ This is done recursively up to N steps. See https://github.com/pacak/cargo-show-
 
 * `cargo-asm` recompiles everything every time with 1 codegen unit, which is slow and also not necessarily what is in your release profile. `cargo-show-asm` avoids that.
 
-* Because of how `cargo-asm` handles demangling the output looks like asm but isn't actually asm. It contains a whole bunch of extra commas which makes reusing it more annoying.
+* Because of how `cargo-asm` handles demangling the output looks like asm but isn't actually asm. It contains a bunch of extra commas which makes reusing it more annoying.
 
 * `cargo-asm` always uses colors unless you pass a flag while `cargo-show-asm` changes its default behavior if output is not sent to a terminal.
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Show the code rustc generates for any function
 - **`    --dry`** &mdash; 
   Produce a build plan instead of actually building
 - **`    --frozen`** &mdash; 
-  Requires `Cargo.lock` and cache to be up-to-date
+  Requires Cargo.lock and cache to be up-to-date
 - **`    --locked`** &mdash; 
-  Requires `Cargo.lock` to be up-to-date
+  Requires Cargo.lock to be up-to-date
 - **`    --offline`** &mdash; 
   Run without accessing the network
 - **`    --no-default-features`** &mdash; 

--- a/README.tpl
+++ b/README.tpl
@@ -12,7 +12,7 @@ $ cargo install cargo-show-asm
 
 - Platform support:
 
-  - OS: Linux and MacOS. Limited support for Windows
+  - OS: Linux and macOS. Limited support for Windows
   - Rust: nightly and stable.
   - Architectures: `x86`, `x86_64`, `aarch64`, etc.
   - Cross-compilation support.
@@ -28,7 +28,7 @@ $ cargo install cargo-show-asm
 
 <USAGE>
 
-You can start by running `cargo asm` with no parameters - it will suggests how to narrow the
+You can start by running `cargo asm` with no parameters - it will suggest how to narrow the
 search scope - for workspace crates you need to specify a crate to work with, for crates
 defining several targets (lib, binaries, examples) you need to specify exactly which target to
 use. In a workspace `cargo asm` lists only workspace members as suggestions but any crate from
@@ -69,7 +69,7 @@ $ cargo asm --lib --full-name
 $ cargo asm --lib "once_cell::imp::OnceCell<T>::initialize::h9c5c7d5bd745000b"
 ```
 
-`cargo-show-asm` comes with a built in search function. Just pass partial name
+`cargo-show-asm` comes with a built-in search function. Just pass partial name
 instead of a full one and only matching functions will be listed
 
 ```console
@@ -80,7 +80,7 @@ $ cargo asm --lib Debug
 
 `rustc` will only generate the code for your function if it knows what type it is, including
 generic parameters and if it is exported (in case of a library) and not inlined (in case of a
-binary, example, test, etc). If your function takes a generic parameter - try making a monomorphic
+binary, example, test, etc.). If your function takes a generic parameter - try making a monomorphic
 wrapper around it and make it `pub` and `#[inline(never)]`.
 
 # Include related functions?
@@ -96,7 +96,7 @@ This is done recursively up to N steps. See https://github.com/pacak/cargo-show-
 
 * `cargo-asm` recompiles everything every time with 1 codegen unit, which is slow and also not necessarily what is in your release profile. `cargo-show-asm` avoids that.
 
-* Because of how `cargo-asm` handles demangling the output looks like asm but isn't actually asm. It contains a whole bunch of extra commas which makes reusing it more annoying.
+* Because of how `cargo-asm` handles demangling the output looks like asm but isn't actually asm. It contains a bunch of extra commas which makes reusing it more annoying.
 
 * `cargo-asm` always uses colors unless you pass a flag while `cargo-show-asm` changes its default behavior if output is not sent to a terminal.
 

--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -55,7 +55,7 @@ pub fn main() {
 
     // Will print in an arbitrary order.
     for x in set.iter() {
-        println!("{}", x);
+        println!("{x}");
     }
 
     println!("Total: {}", get_length(set));
@@ -79,6 +79,6 @@ pub fn okay() {
 
     // Will print in an arbitrary order.
     for x in set.iter() {
-        println!("{}", x);
+        println!("{x}");
     }
 }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -68,8 +68,8 @@ pub fn find_items(lines: &[Statement]) -> BTreeMap<Item, Range<usize>> {
                 // See https://github.com/pacak/cargo-show-asm/issues/110
             }
         } else if line.is_global() && sec_start + 3 < ix {
-            // on Linux and Windows every global function gets it's own section
-            // on Mac for some reason this is not the case so we have to look for
+            // on Linux and Windows every global function gets its own section
+            // on Mac for some reason this is not the case, so we have to look for
             // global variables. This little hack allows to include full section
             // on Windows/Linux but still capture full function body on Mac
             sec_start = ix;
@@ -147,7 +147,7 @@ fn handle_non_mangled_labels(
 
 /// Checks if the provided section `ss` starts with the provided `prefix`.
 /// If it does, it further checks if the section starts with the `label`.
-/// If both conditions are satisfied, it creates a new [`Item`], but sets item.index to 0.
+/// If both conditions are satisfied, it creates a new [`Item`], but sets `item.index` to 0.
 fn get_item_in_section(
     prefix: &str,
     ix: usize,
@@ -191,7 +191,7 @@ fn used_labels<'a>(stmts: &'_ [Statement<'a>]) -> BTreeSet<&'a str> {
             Statement::Instruction(i) => i.args,
             Statement::Dunno(s) => Some(s),
         })
-        .flat_map(crate::demangle::local_labels)
+        .flat_map(demangle::local_labels)
         .map(|m| m.as_str())
         .collect::<BTreeSet<_>>()
 }
@@ -317,7 +317,7 @@ impl Source {
     }
 }
 
-// DWARF information contains references to souce files
+// DWARF information contains references to source files
 // It can point to 3 different items:
 // 1. a real file, cargo-show-asm can just read it
 // 2. a file from rustlib, sources are under $sysroot/lib/rustlib/src/rust/$suffix
@@ -393,7 +393,7 @@ fn locate_sources(sysroot: &Path, workspace: &Path, path: &Path) -> Option<(Sour
         }
     }
 
-    // cargo registry, Linux and MacOS look for cargo/registry and .cargo/registry
+    // cargo registry, Linux and macOS look for cargo/registry and .cargo/registry
     if let Some(ix) = path
         .components()
         .position(|c| c.as_os_str() == "cargo" || c.as_os_str() == ".cargo")

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -107,9 +107,8 @@ impl std::fmt::Display for Directive<'_> {
             Directive::SectionStart(s) => {
                 let dem = demangle::contents(s, display);
                 f.write_str(&format!(
-                    "{} {}",
+                    "{} {dem}",
                     color!(".section", OwoColorize::bright_red),
-                    dem
                 ))
             }
             Directive::SubsectionsViaSym => f.write_str(&format!(

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -28,7 +28,7 @@ const GLOBAL_LABELS_REGEX: &str = r"\b_?(_[a-zA-Z0-9_$\.]+)";
 // 2. LBB[0-9_]+
 // Label kind 1. is a standard label format for GCC and Clang (LLVM)
 // Label kinds 2. was detected in the wild, and don't seem to be a normal label format
-// however it's important to detect them so they can be colored and possibly removed
+// however it's important to detect them, so they can be colored and possibly removed
 //
 // Note on `(?:[^\w\d\$\.]|^)`. This is to prevent the label from matching in the middle of some other word
 // since \b doesn't match before a `.` we can't use \b. So instead we're using a negation of any character
@@ -42,18 +42,18 @@ const LOCAL_LABELS_REGEX: &str = r"(?:[^\w\d\$\.]|^)(\.L[a-zA-Z0-9_\$\.]+|\bLBB[
 const TEMP_LABELS_REGEX: &str = r"\b(Ltmp[0-9]+)\b";
 
 static GLOBAL_LABELS: Lazy<Regex> =
-    Lazy::new(|| regex::Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));
+    Lazy::new(|| Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));
 
 static LOCAL_LABELS: Lazy<Regex> =
-    Lazy::new(|| regex::Regex::new(LOCAL_LABELS_REGEX).expect("regexp should be valid"));
+    Lazy::new(|| Regex::new(LOCAL_LABELS_REGEX).expect("regexp should be valid"));
 
 static LABEL_KINDS: Lazy<RegexSet> = Lazy::new(|| {
-    regex::RegexSet::new([LOCAL_LABELS_REGEX, GLOBAL_LABELS_REGEX, TEMP_LABELS_REGEX])
+    RegexSet::new([LOCAL_LABELS_REGEX, GLOBAL_LABELS_REGEX, TEMP_LABELS_REGEX])
         .expect("regexp should be valid")
 });
 
 static COMMENT_ARGS: Lazy<Regex> =
-    Lazy::new(|| regex::Regex::new(r"(?:\s|^)(#.+)").expect("regexp should be valid"));
+    Lazy::new(|| Regex::new(r"(?:\s|^)(#.+)").expect("regexp should be valid"));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabelKind {
@@ -105,7 +105,7 @@ struct Demangler {
     display: NameDisplay,
 }
 impl Replacer for Demangler {
-    fn replace_append(&mut self, cap: &regex::Captures<'_>, dst: &mut std::string::String) {
+    fn replace_append(&mut self, cap: &regex::Captures<'_>, dst: &mut String) {
         if let Ok(dem) = rustc_demangle::try_demangle(&cap[1]) {
             use std::fmt::Write;
             match self.display {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ use std::{
     ops::Range,
 };
 
+use crate::cached_lines::CachedLines;
 use opts::{Format, NameDisplay, ToDump};
+use std::path::Path;
+
 pub mod asm;
 pub mod cached_lines;
 pub mod demangle;
@@ -251,4 +254,39 @@ fn get_context_for<R: RawLines>(
     }
     out.sort_by_key(|r| r.start);
     out
+}
+
+pub trait Dumpable {
+    fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>>;
+    fn dump_range(fmt: &Format, strings: &[&str]);
+}
+
+/// dump LLVM and MIR code
+///
+/// # Errors
+/// Reports file IO errors
+pub fn dump_function<T: Dumpable>(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<()> {
+    // For some reason llvm/rustc can produce non utf8 files...
+    let payload = std::fs::read(path)?;
+    let contents = String::from_utf8_lossy(&payload).into_owned();
+    let lines = CachedLines::without_ending(contents);
+    let items = T::find_items(&lines);
+    let strs = lines.iter().collect::<Vec<_>>();
+    match get_dump_range(goal, fmt, &items) {
+        Some(range) => {
+            let context = get_context_for(fmt.context, &strs[..], range.clone(), &items);
+            T::dump_range(fmt, &strs[range]);
+            if !context.is_empty() {
+                safeprintln!(
+                    "\n\n======================= Additional context ========================="
+                );
+                for range in context {
+                    safeprintln!("\n");
+                    T::dump_range(fmt, &strs[range]);
+                }
+            }
+        }
+        None => T::dump_range(fmt, &strs),
+    };
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::Context;
 use cargo_metadata::{Artifact, Message, MetadataCommand, Package};
-use cargo_show_asm::{asm, esafeprintln, llvm, mca, mir, opts};
+use cargo_show_asm::dump_function;
+use cargo_show_asm::llvm::Llvm;
+use cargo_show_asm::mir::Mir;
+use cargo_show_asm::{asm, esafeprintln, mca, opts};
 use once_cell::sync::Lazy;
 use std::{
     io::BufReader,
@@ -251,9 +254,9 @@ fn main() -> anyhow::Result<()> {
             &opts.target_cpu,
         ),
         Syntax::Llvm | Syntax::LlvmInput => {
-            llvm::dump_function(opts.to_dump, &asm_path, &opts.format)
+            dump_function::<Llvm>(opts.to_dump, &asm_path, &opts.format)
         }
-        Syntax::Mir => mir::dump_function(opts.to_dump, &asm_path, &opts.format),
+        Syntax::Mir => dump_function::<Mir>(opts.to_dump, &asm_path, &opts.format),
     }
 }
 
@@ -365,7 +368,7 @@ fn locate_asm_path_via_artifact(artifact: &Artifact, expect_ext: &str) -> anyhow
 
     // For bin or bin-type example artifacts, `filenames` provide hard-linked paths
     // without extra-filename.
-    // We scans all possible original artifacts by checking hard links,
+    // We scan all possible original artifacts by checking hard links,
     // in order to retrieve the correct extra-filename, and then locate asm files.
     //
     // `filenames`, also `executable`:

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -52,7 +52,7 @@ pub fn dump_function(
         .stderr(Stdio::piped());
 
     if fmt.verbosity >= 2 {
-        safeprintln!("running {:?}", mca);
+        safeprintln!("running {mca:?}");
     }
     let mca = mca.spawn();
     let mut mca = match mca {

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -1,93 +1,62 @@
-use crate::{
-    cached_lines::CachedLines,
-    color, get_context_for, get_dump_range,
-    opts::{Format, ToDump},
-    safeprintln, Item,
-};
+use crate::Dumpable;
+use crate::{cached_lines::CachedLines, color, opts::Format, safeprintln, Item};
 use owo_colors::OwoColorize;
-use std::{collections::BTreeMap, ops::Range, path::Path};
+use std::{collections::BTreeMap, ops::Range};
 
-fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>> {
-    let mut res = BTreeMap::new();
-    let mut current_item = None::<Item>;
-    let mut block_start = None;
+pub struct Mir;
 
-    for (ix, line) in lines.iter().enumerate() {
-        if line.starts_with("//") {
-            if block_start.is_none() {
-                block_start = Some(ix);
-            }
-        } else if line == "}" {
-            if let Some(mut cur) = current_item.take() {
-                // go home clippy, you're drunk
-                #[allow(clippy::range_plus_one)]
-                let range = cur.len..ix + 1;
-                cur.len = range.len();
-                res.insert(cur, range);
-            }
-        } else if !(line.starts_with(' ') || line.is_empty()) && current_item.is_none() {
-            let start = block_start.take().unwrap_or(ix);
-            let mut name = line;
-            'outer: loop {
-                for suffix in [" {", " =", " -> ()"] {
-                    if let Some(rest) = name.strip_suffix(suffix) {
-                        name = rest;
-                        continue 'outer;
+impl Dumpable for Mir {
+    fn find_items(lines: &CachedLines) -> BTreeMap<Item, Range<usize>> {
+        let mut res = BTreeMap::new();
+        let mut current_item = None::<Item>;
+        let mut block_start = None;
+
+        for (ix, line) in lines.iter().enumerate() {
+            if line.starts_with("//") {
+                if block_start.is_none() {
+                    block_start = Some(ix);
+                }
+            } else if line == "}" {
+                if let Some(mut cur) = current_item.take() {
+                    // go home clippy, you're drunk
+                    #[allow(clippy::range_plus_one)]
+                    let range = cur.len..ix + 1;
+                    cur.len = range.len();
+                    res.insert(cur, range);
+                }
+            } else if !(line.starts_with(' ') || line.is_empty()) && current_item.is_none() {
+                let start = block_start.take().unwrap_or(ix);
+                let mut name = line;
+                'outer: loop {
+                    for suffix in [" {", " =", " -> ()"] {
+                        if let Some(rest) = name.strip_suffix(suffix) {
+                            name = rest;
+                            continue 'outer;
+                        }
                     }
+                    break;
                 }
-                break;
-            }
-            current_item = Some(Item {
-                mangled_name: name.to_owned(),
-                name: name.to_owned(),
-                hashed: name.to_owned(),
-                index: res.len(),
-                len: start,
-                non_blank_len: 0,
-            });
-        }
-    }
-
-    res
-}
-
-fn dump_range(_fmt: &Format, strings: &[&str]) {
-    for line in strings {
-        if let Some(ix) = line.rfind("//") {
-            safeprintln!("{}{}", &line[..ix], color!(&line[ix..], OwoColorize::cyan));
-        } else {
-            safeprintln!("{line}");
-        }
-    }
-}
-
-/// dump mir code
-///
-/// # Errors
-/// Reports file IO errors
-pub fn dump_function(goal: ToDump, path: &Path, fmt: &Format) -> anyhow::Result<()> {
-    // For some reason llvm/rustc can produce non utf8 files...
-    let payload = std::fs::read(path)?;
-    let contents = String::from_utf8_lossy(&payload).into_owned();
-    let lines = CachedLines::without_ending(contents);
-    let items = find_items(&lines);
-    let strs = lines.iter().collect::<Vec<_>>();
-    match get_dump_range(goal, fmt, &items) {
-        Some(range) => {
-            let context = get_context_for(fmt.context, &strs[..], range.clone(), &items);
-            dump_range(fmt, &strs[range]);
-
-            if !context.is_empty() {
-                safeprintln!(
-                    "\n\n======================= Additional context ========================="
-                );
-                for range in context {
-                    safeprintln!("\n");
-                    dump_range(fmt, &strs[range]);
-                }
+                current_item = Some(Item {
+                    mangled_name: name.to_owned(),
+                    name: name.to_owned(),
+                    hashed: name.to_owned(),
+                    index: res.len(),
+                    len: start,
+                    non_blank_len: 0,
+                });
             }
         }
-        None => dump_range(fmt, &strs),
-    };
-    Ok(())
+
+        res
+    }
+
+    fn dump_range(_fmt: &Format, strings: &[&str]) {
+        for line in strings {
+            if let Some(ix) = line.rfind("//") {
+                safeprintln!("{}{}", &line[..ix], color!(&line[ix..], OwoColorize::cyan));
+            } else {
+                safeprintln!("{line}");
+            }
+        }
+    }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -27,7 +27,7 @@ fn check_target_dir(path: PathBuf) -> anyhow::Result<PathBuf> {
 ///   3. Get the full results:
 ///      % cargo asm -p isin --lib isin::base36::from_alphanum
 pub struct Options {
-    // here is the the code located
+    // here is the code located
     #[bpaf(external)]
     pub select_fragment: SelectFragment,
 
@@ -87,10 +87,10 @@ pub struct Cargo {
     /// Produce a build plan instead of actually building
     #[bpaf(hide_usage)]
     pub dry: bool,
-    /// Requires Cargo.lock and cache are up to date
+    /// Requires `Cargo.lock` and cache to be up-to-date
     #[bpaf(hide_usage)]
     pub frozen: bool,
-    /// Requires Cargo.lock is up to date
+    /// Requires `Cargo.lock` to be up-to-date
     #[bpaf(hide_usage)]
     pub locked: bool,
     /// Run without accessing the network

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -87,10 +87,10 @@ pub struct Cargo {
     /// Produce a build plan instead of actually building
     #[bpaf(hide_usage)]
     pub dry: bool,
-    /// Requires `Cargo.lock` and cache to be up-to-date
+    /// Requires Cargo.lock and cache to be up-to-date
     #[bpaf(hide_usage)]
     pub frozen: bool,
-    /// Requires `Cargo.lock` to be up-to-date
+    /// Requires Cargo.lock to be up-to-date
     #[bpaf(hide_usage)]
     pub locked: bool,
     /// Run without accessing the network


### PR DESCRIPTION
Thanks for a great tool!  I used it a bit for my attempts at making Rust [a bit faster](https://github.com/rust-lang/rust/pull/121001) (no luck so far, but hopeful), so figured will contribute a bit back.

* introduced a new `Dumpable` trait and made MIR and LLVM implement it - so that `dump_function` can share both implementations (it was identical for both)
* removed a few un-needed/inconsistent qualifiers
* ran spellchecker
* inlined a few format args