### PR TITLE
Release 0.2.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]


### PR DESCRIPTION
- include relevant constants in produced asm output, this can be disabled with `--no-constants` [#261]
- bump deps
- lower MSRV