### PR TITLE
Don't include constants by default - noisy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.35] - unreleased
+- don't include constants by default
+
 ## [0.2.34] - 2024-04-25
 - don't force debuginfo in llvm, fixes #269
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`-c`**=_`COUNT`_\] \[**`--simplify`**\] \[**`--no-constants`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] _`OUTPUT-FORMAT`_ \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`-c`**=_`COUNT`_\] \[**`--simplify`**\] \[**`--include-constants`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] _`OUTPUT-FORMAT`_ \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -133,8 +133,8 @@ Show the code rustc generates for any function
   more verbose output, can be specified multiple times
 - **`    --simplify`** &mdash; 
   Try to strip some of the non-assembly instruction information
-- **`    --no-constants`** &mdash; 
-  Don't detect/include sections containing string literals and other constants
+- **`    --include-constants`** &mdash; 
+  Include sections containing string literals and other constants
 - **`-b`**, **`--keep-blank`** &mdash; 
   Keep blank lines
 - **`    --this-workspace`** &mdash; 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -248,8 +248,7 @@ pub struct Format {
     /// Try to strip some of the non-assembly instruction information
     pub simplify: bool,
 
-    /// Don't detect/include sections containing string literals and other constants
-    #[bpaf(long("no-constants"), flag(false, true))]
+    /// Include sections containing string literals and other constants
     pub include_constants: bool,
 
     /// Keep blank lines


### PR DESCRIPTION
You can pass `--include-constants` to see them