### PR TITLE
Release 0.2.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.34"
+version = "0.2.35"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.2.35] - 2024-05-05
+## [0.2.35] - 2024-05-06
 - don't include constants by default
 - include local jump labels in disassembly
 - include instructions in hex in disassembly

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Show the code rustc generates for any function
 - **`    --asm`** &mdash; 
   Show assembly
 - **`    --disasm`** &mdash; 
-  Disassembly binaries
+  Disassembly binaries or object files
 - **`    --llvm`** &mdash; 
   Show llvm-ir
 - **`    --llvm-input`** &mdash; 

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -253,7 +253,7 @@ fn dump_slices(
             use owo_colors::OwoColorize;
             safeprintln!(
                 "{}{}:",
-                crate::color!("label_", OwoColorize::bright_yellow),
+                crate::color!(".L", OwoColorize::bright_yellow),
                 crate::color!(id, OwoColorize::bright_yellow),
             );
         }
@@ -269,7 +269,7 @@ fn dump_slices(
             write!(
                 buf,
                 "{}{}",
-                color!("label_", OwoColorize::bright_yellow),
+                color!(".L", OwoColorize::bright_yellow),
                 color!(id, OwoColorize::bright_yellow)
             )
             .unwrap();

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -58,7 +58,6 @@ pub enum CodeSource {
         #[bpaf(external(cargo))]
         cargo: Cargo,
     },
-    #[cfg(feature = "disasm")]
     File {
         /// Disassemble this file instead of calling cargo,
         ///  requires cargo-show-asm to be compiled with disasm feature
@@ -305,8 +304,7 @@ pub enum NameDisplay {
 pub enum OutputType {
     /// Show assembly
     Asm,
-    /// Disassembly binaries
-    #[cfg(feature = "disasm")]
+    /// Disassembly binaries or object files
     Disasm,
     /// Show llvm-ir
     Llvm,
@@ -366,7 +364,6 @@ impl Syntax {
             OutputType::LlvmInput => Some("no-prepopulate-passes"),
             OutputType::Llvm | OutputType::Mir | OutputType::Wasm => None,
 
-            #[cfg(feature = "disasm")]
             OutputType::Disasm => None,
         }
     }
@@ -378,7 +375,6 @@ impl Syntax {
             OutputType::Llvm | OutputType::LlvmInput => Some("llvm-ir"),
             OutputType::Mir => Some("mir"),
 
-            #[cfg(feature = "disasm")]
             OutputType::Disasm => None,
         }
     }
@@ -390,7 +386,6 @@ impl Syntax {
             OutputType::Llvm | OutputType::LlvmInput => Some("ll"),
             OutputType::Mir => Some("mir"),
 
-            #[cfg(feature = "disasm")]
             OutputType::Disasm => None,
         }
     }
@@ -532,7 +527,6 @@ fn write_updated(new_val: &str, path: impl AsRef<std::path::Path>) -> std::io::R
 
 #[cfg(unix)]
 #[test]
-#[cfg(feature = "disasm")]
 fn docs_are_up_to_date() {
     let usage = options().render_markdown("cargo asm");
     let readme = std::fs::read_to_string("README.tpl").unwrap();


### PR DESCRIPTION
Mostly changes to disassembler (compile with "disasm" feature, pass `--disasm`)

- don't include constants by default
- include local jump labels in disassembly
- include instructions in hex in disassembly
- avoid memory addresses with displacement in disassembly
- bump bpaf