### PR TITLE
Test mangled named on Windows too

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -138,8 +138,14 @@ jobs:
       - name: Rlib project, AT&T asm
         run: cargo run -- --manifest-path sample_rlib/Cargo.toml --att
 
-      - name: cdylib project
+      - name: cdylib project, everything
         run: cargo run -- --manifest-path sample_cdylib/Cargo.toml --everything
+
+      - name: cdylib project
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml add
+
+      - name: cdylib project, underscore prefix
+        run: cargo run -- --manifest-path sample_cdylib/Cargo.toml _mul
 
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
We need to strip underscore on 32bit Windows and MacOS and leave it as is on Linux and 64bit  Windows.

Fixes https://github.com/pacak/cargo-show-asm/issues/137