### PR TITLE
Release 0.2.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.36"
+version = "0.2.37"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.2.37] - 2024-06-27
+- support combination of --everything and --rust
+- bump deps
+
 ## [0.2.36] - 2024-06-02
 - even better support for no_mangle names on windows
   thanks to @evmar

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,13 @@ pub fn dump_function<T: Dumpable>(
                 }
             }
         }
-        None => dumpable.dump_range(fmt, &lines)?,
+        None => {
+            if fmt.rust {
+                // for asm files extra_context loads rust sources
+                T::extra_context(dumpable, fmt, &lines, 0..lines.len(), &items);
+            }
+            dumpable.dump_range(fmt, &lines)?
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
- Support a combination of `--rust` and `--everything`
- bump deps


Fixes #289