### PR TITLE
Release 0.2.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.38"
+version = "0.2.39"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]


### PR DESCRIPTION
- support `--config KEY=VAL` option that is passed directly to cargo (#305)
- bump deps 