### PR TITLE
Fix item selection if there is only one item found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,12 +160,6 @@ pub fn pick_dump_item<K: Clone>(
     fmt: &Format,
     items: &BTreeMap<Item, K>,
 ) -> Option<K> {
-    let mut items_values = items.values();
-    if let [Some(item), None] = array::from_fn(|_| items_values.next()) {
-        // Automatically pick an item if only one is found
-        return Some(item.clone());
-    }
-
     match goal {
         // to dump everything just return an empty range
         ToDump::Everything => None,
@@ -211,10 +205,16 @@ pub fn pick_dump_item<K: Clone>(
             Some(range)
         }
 
-        // Unspecified, so print suggestions and exit
         ToDump::Unspecified => {
-            let items = items.keys();
-            suggest_name("", &fmt.name_display, items);
+            let mut items_values = items.values();
+            if let [Some(item), None] = array::from_fn(|_| items_values.next()) {
+                // Automatically pick an item if only one is found
+                Some(item.clone())
+            } else {
+                // Otherwise, print suggestions and exit
+                let items = items.keys();
+                suggest_name("", &fmt.name_display, items);
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 use opts::{Format, NameDisplay, ToDump};
 use std::{
+    array,
     collections::{BTreeMap, BTreeSet},
     ops::Range,
     path::{Path, PathBuf},
@@ -108,7 +109,7 @@ pub fn suggest_name<'a>(
     search: &str,
     name_display: &NameDisplay,
     items: impl IntoIterator<Item = &'a Item>,
-) {
+) -> ! {
     let mut count = 0usize;
     let names: BTreeMap<&String, Vec<usize>> =
         items.into_iter().fold(BTreeMap::new(), |mut m, item| {
@@ -159,15 +160,12 @@ pub fn pick_dump_item<K: Clone>(
     fmt: &Format,
     items: &BTreeMap<Item, K>,
 ) -> Option<K> {
-    if items.len() == 1 {
-        return Some(
-            items
-                .values()
-                .next()
-                .cloned()
-                .expect("We just checked there's one item present"),
-        );
+    let mut items_values = items.values();
+    if let [Some(item), None] = array::from_fn(|_| items_values.next()) {
+        // Automatically pick an item if only one is found
+        return Some(item.clone());
     }
+
     match goal {
         // to dump everything just return an empty range
         ToDump::Everything => None,
@@ -217,7 +215,6 @@ pub fn pick_dump_item<K: Clone>(
         ToDump::Unspecified => {
             let items = items.keys();
             suggest_name("", &fmt.name_display, items);
-            unreachable!("suggest_name exits");
         }
     }
 }


### PR DESCRIPTION
When an item is specified in arguments, it is expected that no matter how many items are found, the requested item will be shown. When the `--everything` option is given, it is expected that no matter how many items are found, "everything" will be shown.

Currently (without this PR) if there is only one item found, it will always return only this item, regardless of what is requested on the command line.

This PR moves the automatic selection of a single item later,  after checking that we have not selected anything (or `--everything`) for display.

Also, if you don't mind, this PR removes the unnecessary `expect` and `unreachable` in the moved fragment with a little refactoring. I can revert some of the changes if something is not okay or less readable.

## Example

```rust
pub static DATA: &[u8] = &[1, 2, 3, 4];
#[inline(never)]
pub fn ret_true() -> bool {
    true
}
```

### Current output (without this PR)
```
$ cargo asm --lib ret_true
.section .text.example::ret_true,"ax",@progbits
	.globl	example::ret_true
	.p2align	4, 0x90
	.type	example::ret_true,@function
example::ret_true:
	.cfi_startproc
	mov al, 1
	ret

$ cargo asm --lib ret_false
.section .text.example::ret_true,"ax",@progbits
	.globl	example::ret_true
	.p2align	4, 0x90
	.type	example::ret_true,@function
example::ret_true:
	.cfi_startproc
	mov al, 1
	ret

$ echo $?
0

$ cargo asm --lib --everything
.section .text.example::ret_true,"ax",@progbits
	.globl	example::ret_true
	.p2align	4, 0x90
	.type	example::ret_true,@function
example::ret_true:
	.cfi_startproc
	mov al, 1
	ret
```

### Expected (with this PR)
```
$ cargo asm --lib ret_true
.section .text.example::ret_true,"ax",@progbits
	.globl	example::ret_true
	.p2align	4, 0x90
	.type	example::ret_true,@function
example::ret_true:
	.cfi_startproc
	mov al, 1
	ret

$ cargo asm --lib ret_false
Can't find any items matching "ret_false"

$ echo $?
1

$ cargo asm --lib --everything
	.text
	.intel_syntax noprefix
	.file	"example.cb5693eae6d1f11e-cgu.0"
.section .text.example::ret_true,"ax",@progbits
	.globl	example::ret_true
	.p2align	4, 0x90
	.type	example::ret_true,@function
example::ret_true:
	.cfi_startproc
	mov al, 1
	ret
	.size	example::ret_true, .Lfunc_end0-example::ret_true
	.cfi_endproc
	.type	.L__unnamed_1,@object
.section .rodata.cst4,"aM",@progbits,4
	.ascii	"\001\002\003\004"
	.size	.L__unnamed_1, 4
	.type	example::DATA,@object
.section .data.rel.ro.example::DATA,"aw",@progbits
	.globl	example::DATA
	.p2align	3, 0x0
example::DATA:
	.quad	.L__unnamed_1
	.asciz	"\004\000\000\000\000\000\000"
	.size	example::DATA, 16
.section .debug_abbrev,"",@progbits
................................................................
```

## Tests

Checked with example about on linux x86_64 and with `cargo test`.