### PR TITLE
Release 0.2.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.39"
+version = "0.2.40"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.2.40] - 2024-10-01
+- more consistend behavior when only one item is detected (#312)
+  thanks @zheland
+- fixed llvm output for no_mangle functions (#313)
+  thanks @zheland
+- bump deps
+
 ## [0.2.39] - 2024-09-19
 - support --config KEY=VAL option that is passed directly to cargo
 - bump deps


### PR DESCRIPTION
- more consistend behavior when only one item is detected (#312)
- fixed llvm output for no_mangle functions (#313)
- bump deps