### PR TITLE
Make sure not to drop used labels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [0.2.41] - Unreleased
+- make sure not to drop used labels (#318)
 - add release-lto profile for slightly smaller/faster version
   thanks @zamazan4ik for the suggestion
 - detect and render merged functions (#310)

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -263,7 +263,6 @@ fn used_labels<'a>(stmts: &'_ [Statement<'a>]) -> BTreeSet<&'a str> {
             Statement::Dunno(s) => Some(s),
         })
         .flat_map(demangle::local_labels)
-        .map(|m| m.as_str())
         .collect::<BTreeSet<_>>()
 }
 
@@ -629,11 +628,8 @@ impl<'a> Dumpable for Asm<'a> {
                     })
                     | Statement::Directive(Directive::Generic(GenericDirective(arg))) = s
                     {
-                        for label in crate::demangle::local_labels_reg().find_iter(arg) {
-                            let referenced_label = label.as_str().trim();
-                            if let Some(constant_range) =
-                                scan_constant(referenced_label, &sections, lines)
-                            {
+                        for label in crate::demangle::local_labels(arg) {
+                            if let Some(constant_range) = scan_constant(label, &sections, lines) {
                                 if !seen.contains(&constant_range)
                                     && !print_range.fully_contains(constant_range)
                                 {


### PR DESCRIPTION
Regexp find returns the whole group, including non capturing part, so we can't use it directly. This MR makes regexes more private and uses capture groups to extract labels

Fixes #318