### PR TITLE
Release 0.2.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.40"
+version = "0.2.41"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.2.41] - Unreleased
+## [0.2.41] - 2024-10-13
 - make sure not to drop used labels (#318)
 - add release-lto profile for slightly smaller/faster version
   thanks @zamazan4ik for the suggestion

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Show the code rustc generates for any function
 
   required for workspace projects, can also point to a dependency
 - **`    --file`**=_`PATH`_ &mdash; 
-  Disassemble this file instead of calling cargo,
+  Disassemble or process this file instead of calling cargo,
 requires cargo-show-asm to be compiled with disasm feature
 
   You can specify executable, rlib or an object file

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -847,15 +847,18 @@ fn good_for_label(c: char) -> bool {
     c == '.' || c == '$' || c == '_' || c.is_ascii_alphanumeric()
 }
 impl Statement<'_> {
+    /// Is this a label that starts with ".Lfunc_end"?
     pub(crate) fn is_end_of_fn(&self) -> bool {
         let check_id = |id: &str| id.strip_prefix('.').unwrap_or(id).starts_with("Lfunc_end");
         matches!(self, Statement::Label(Label { id, .. }) if check_id(id))
     }
 
+    /// Is this a .section directive?
     pub(crate) fn is_section_start(&self) -> bool {
         matches!(self, Statement::Directive(Directive::SectionStart(_)))
     }
 
+    /// Is this a .global directive?
     pub(crate) fn is_global(&self) -> bool {
         matches!(self, Statement::Directive(Directive::Global(_)))
     }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -59,7 +59,7 @@ pub enum CodeSource {
         cargo: Cargo,
     },
     File {
-        /// Disassemble this file instead of calling cargo,
+        /// Disassemble or process this file instead of calling cargo,
         ///  requires cargo-show-asm to be compiled with disasm feature
         ///
         /// You can specify executable, rlib or an object file


### PR DESCRIPTION
In short - a whole lot of bugfixes

- make sure not to drop used labels (#318)
- add `release-lto` profile for slightly smaller/faster version - you have to use it yourself, by default it is still `release`
  thanks zamazan4ik for the suggestion
- detect and render merged functions (#310)
- update docs (#320)
- smarter approach for detecting constants (#315)
- smarter CI (#79)
- bump deps