### PR TITLE
Release 0.2.42

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -212,29 +212,29 @@ jobs:
       - name: merged functions simd
         shell: bash
         if: ${{ !cancelled() && matrix.os != 'macos-latest' }} # uses x86 primops
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::merged_0 --include-constants
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::merged_0 --include-constants -c 1
 
       - name: merged functions simd
         shell: bash
         if: ${{ !cancelled() && matrix.os != 'macos-latest' }} # uses x86 primops
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::merged_1 --include-constants
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::merged_1 --include-constants -c 1
 
       - name: merged functions extern c
         shell: bash
         if: ${{ !cancelled() }}
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::extern_c_0
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::extern_c_0 -c 1
 
       - name: merged functions extern c
         shell: bash
         if: ${{ !cancelled() }}
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::extern_c_1
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::extern_c_1 -c 1
 
       - name: merged functions plain
         shell: bash
         if: ${{ !cancelled() }}
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::plain_0
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::plain_0 -c 1
 
       - name: merged functions plain
         shell: bash
         if: ${{ !cancelled() }}
-        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::plain_1
+        run: ./.github/check.sh --manifest-path sample_merged/Cargo.toml sample_merged::plain_1 -c 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.41"
+version = "0.2.42"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,10 @@
 # Change Log
 
-## [0.2.42] - unreleased
+## [0.2.42] - 2024-11-10
 - `--quiet` option that gets passed to `cargo
+- Also search for context in `.set` statements - for merged functions
+  this mean that when you are showing the alias with `-c 1` - the actual
+  implementation will show up as well (#338)
 
 ## [0.2.41] - 2024-10-13
 - make sure not to drop used labels (#318)

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -566,6 +566,7 @@ impl RawLines for Statement<'_> {
     fn lines(&self) -> Option<&str> {
         match self {
             Statement::Instruction(i) => i.args,
+            Statement::Directive(Directive::SetValue(_, i)) => Some(i),
             _ => None,
         }
     }


### PR DESCRIPTION
- `--quiet` option that gets passed to `cargo
- Also search for context in `.set` statements - for merged functions
  this mean that when you are showing the alias with `-c 1` - the actual
  implementation will show up as well (Fixes #338)