### PR TITLE
Trace used cargo command in verbose mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,10 @@ fn spawn_cargo(
         cmd.arg("-Ccodegen-units=1");
     }
 
+    if format.verbosity >= 2 {
+        safeprintln!("Running: {cmd:?}");
+    }
+
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
I suggest printing  the `cargo` command used to generate the output in verbose output mode.
`cargo asm` is very handy, but sometimes it is more convenient to use a lower-level command. Then `cargo asm -v` can help by telling you what flags you can use to get a similar output. And also just for debugging purposes.

The change is based on similar code from `Mca::dump_range`:
https://github.com/pacak/cargo-show-asm/blob/60cf36623ad04e78d008db1a6a433be5db5491a3/src/mca.rs#L59-L61
but using capitalized "Running" word and colon (more consistent with other printed information from cargo-show-asm), and verbosity `>= 1` condition (similar to `cargo` verbosity for printing running commands).

# Example

`cargo run -- --bin cargo-asm -v`

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/cargo-asm --bin cargo-asm -v`
Found sysroot: ...../.rustup/toolchains/stable-x86_64-unknown-linux-gnu
Running: "...../.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo" "rustc" "--message-format=json-render-diagnostics" "--color" "always" "-v" "--manifest-path" "...../cargo-show-asm/Cargo.toml" "--config" "profile.release.strip=false" "--package" "cargo-show-asm" "--bin" "cargo-asm" "--release" "--" "--emit" "asm" "-C" "llvm-args=-x86-asm-syntax=intel" "-Cdebuginfo=2" "-Ccodegen-units=1"
       Fresh unicode-ident v1.0.12
       .....
       Fresh cargo-show-asm v0.2.42 (...../cargo-show-asm)
    Finished `release` profile [optimized] target(s) in 0.02s

Artifact files: ["...../cargo-show-asm/target/release/cargo-asm"]
Working with file: ...../cargo-show-asm/target/release/deps/cargo_asm-538c737cc8d17c28.s
Try one of those by name or a sequence number
.....
```