### PR TITLE
Add a `-s`/`--silent` option to silence user-facing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Show the code rustc generates for any function
   Strip redundant labels entirely
 - **`-v`**, **`--verbose`** &mdash; 
   more verbose output, can be specified multiple times
+- **`-s`**, **`--silent`** &mdash; 
+  print less user-forward information to make consumption by tools easier
 - **`    --simplify`** &mdash; 
   Try to strip some of the non-assembly instruction information
 - **`    --include-constants`** &mdash; 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -544,7 +544,9 @@ fn load_rust_sources(
                     }
                     let sources = std::fs::read_to_string(&filepath).expect("Can't read a file");
                     if sources.is_empty() {
-                        safeprintln!("Ignoring empty file {filepath:?}!");
+                        if fmt.verbosity > 0 {
+                            safeprintln!("Ignoring empty file {filepath:?}!");
+                        }
                         (path, None)
                     } else {
                         if fmt.verbosity > 2 {

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -201,7 +201,7 @@ fn dump_slices(
     }
 
     let insns = cs.disasm_all(code, addr as u64)?;
-    if insns.is_empty() {
+    if insns.is_empty() && fmt.verbosity > 0 {
         safeprintln!("No instructions - empty code block?");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub fn pick_dump_item<K: Clone>(
                 Some(range.clone())
             } else {
                 let actual = items.len();
-                safeprintln!("You asked to display item #{value} (zero based), but there's only {actual} items");
+                esafeprintln!("You asked to display item #{value} (zero based), but there's only {actual} items");
                 std::process::exit(1);
             }
         }
@@ -192,13 +192,13 @@ pub fn pick_dump_item<K: Clone>(
                 range.1.clone()
             } else if let Some(value) = nth {
                 let filtered = filtered.len();
-                safeprintln!("You asked to display item #{value} (zero based), but there's only {filtered} matching items");
+                esafeprintln!("You asked to display item #{value} (zero based), but there's only {filtered} matching items");
                 std::process::exit(1);
             } else {
                 if filtered.is_empty() {
-                    safeprintln!("Can't find any items matching {function:?}");
+                    esafeprintln!("Can't find any items matching {function:?}");
                 } else {
-                    suggest_name(&function, &fmt.name_display, filtered.iter().map(|x| x.0));
+                    suggest_name(&function, &fmt, filtered.iter().map(|x| x.0));
                 }
                 std::process::exit(1);
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,14 +107,14 @@ pub struct Item {
 
 pub fn suggest_name<'a>(
     search: &str,
-    name_display: &NameDisplay,
+    fmt: &Format,
     items: impl IntoIterator<Item = &'a Item>,
 ) -> ! {
     let mut count = 0usize;
     let names: BTreeMap<&String, Vec<usize>> =
         items.into_iter().fold(BTreeMap::new(), |mut m, item| {
             count += 1;
-            let entry = match name_display {
+            let entry = match fmt.name_display {
                 NameDisplay::Full => &item.hashed,
                 NameDisplay::Short => &item.name,
                 NameDisplay::Mangled => &item.mangled_name,
@@ -123,15 +123,19 @@ pub fn suggest_name<'a>(
             m
         });
 
-    if names.is_empty() {
-        if search.is_empty() {
-            safeprintln!("This target defines no functions (or cargo-show-asm can't find them)");
+    if fmt.verbosity > 0 {
+        if names.is_empty() {
+            if search.is_empty() {
+                safeprintln!(
+                    "This target defines no functions (or cargo-show-asm can't find them)"
+                );
+            } else {
+                safeprintln!("No matching functions, try relaxing your search request");
+            }
+            safeprintln!("You can pass --everything to see the demangled contents of a file");
         } else {
-            safeprintln!("No matching functions, try relaxing your search request");
+            safeprintln!("Try one of those by name or a sequence number");
         }
-        safeprintln!("You can pass --everything to see the demangled contents of a file");
-    } else {
-        safeprintln!("Try one of those by name or a sequence number");
     }
 
     #[allow(clippy::cast_sign_loss)]
@@ -213,7 +217,7 @@ pub fn pick_dump_item<K: Clone>(
             } else {
                 // Otherwise, print suggestions and exit
                 let items = items.keys();
-                suggest_name("", &fmt.name_display, items);
+                suggest_name("", &fmt, items);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn spawn_cargo(
             "--color",
             if format.color { "always" } else { "never" },
         ])
-        .args(std::iter::repeat("-v").take(format.verbosity))
+        .args(std::iter::repeat("-v").take(format.verbosity.saturating_sub(1)))
         // Workspace location.
         .arg("--manifest-path")
         .arg(&cargo.manifest_path)

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -202,13 +202,19 @@ pub enum CompileMode {
 }
 
 fn verbosity() -> impl Parser<usize> {
-    short('v')
+    let verbose = short('v')
         .long("verbose")
         .help("more verbose output, can be specified multiple times")
         .req_flag(())
-        .many()
-        .map(|v| v.len())
         .hide_usage()
+        .count();
+    let silent = short('s')
+        .long("silent")
+        .help("print less user-forward information to make consumption by tools easier")
+        .req_flag(())
+        .hide_usage()
+        .count();
+    construct!(verbose, silent).map(|(v, q)| (v + 1).saturating_sub(q))
 }
 
 fn manifest_path() -> impl Parser<PathBuf> {


### PR DESCRIPTION
I have a usecase where it would be nice to use cargo-show-asm programmatically, since it does a nicer job of filtering and demangling than most builtin utilities. However, UI messages currently print to stdout, meaning they need to be manually filtered:

    $ cargo asm -p libm --lib 2>/dev/null | cat
    Try one of those by name or a sequence number
      0 "<f32 as libm::math::support::float_traits::Float>::abs" [9]
      1 "<f32 as libm::math::support::float_traits::Float>::copysign" [18]
      2 "<f32 as libm::math::support::float_traits::Float>::normalize" [21]
      3 "<f64 as libm::math::support::float_traits::Float>::abs" [9]

Introduce a `-s`/`--silent` flag that reduces the verbosity level, effectively being the the opposite of `-v`:

    $ path/cargo-asm asm -p libm --lib -s 2>/dev/null | cat
      0 "<f32 as libm::math::support::float_traits::Float>::abs" [9]
      1 "<f32 as libm::math::support::float_traits::Float>::copysign" [18]
      2 "<f32 as libm::math::support::float_traits::Float>::normalize" [21]
      3 "<f64 as libm::math::support::float_traits::Float>::abs" [9]

`-s` was chosen to mirror Curl, since `-q` is already used as the flag to quieten Cargo's output.