### PR TITLE
Release 0.2.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.46"
+version = "0.2.47"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.46"
+version = "0.2.47"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.47] - 2025-01-21
+- don't try to override RUSTFLAGS unless needed - this should keep .config/cargo working (#364)
+
 ## [0.2.46] - 2025-01-15
 - `--silent` flag can be used to suppress some of the user directed informatin
   thanks @tgross35

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,9 +140,11 @@ fn spawn_cargo(
         cmd.arg("-Ccodegen-units=1");
     }
 
-    // `args` from `cargo rustc -- args` are passed only to the final compiler instance.
-    // `RUSTFLAGS` envvar is useful for passing flags to all compiler instances.
-    cmd.env("RUSTFLAGS", rust_flags.trim_start());
+    if !rust_flags.is_empty() {
+        // `args` from `cargo rustc -- args` are passed only to the final compiler instance.
+        // `RUSTFLAGS` envvar is useful for passing flags to all compiler instances.
+        cmd.env("RUSTFLAGS", rust_flags.trim_start());
+    }
 
     if format.verbosity >= 2 {
         safeprintln!("Running: {cmd:?}");


### PR DESCRIPTION
- don't try to override `RUSTFLAGS` unless needed - this should keep `.config/cargo` working (Fixes #364)