### PR TITLE
Don't add .intel_syntax on non-Intel machines

### DIFF
--- a/src/mca.rs
+++ b/src/mca.rs
@@ -73,9 +73,18 @@ impl Dumpable for Mca<'_> {
         let o = mca.stdout.take().expect("Stdout should be piped");
         let e = mca.stderr.take().expect("Stderr should be piped");
 
+        let is_x86 = self
+            .target_triple
+            .map(|t| t.starts_with("x86_64-") || t.starts_with("i686-") || t.starts_with("i586-"))
+            .unwrap_or(cfg!(target_arch = "x86_64") || cfg!(target_arch = "x86"));
+
         match self.output_style {
             // without that llvm-mca gets confused for some instructions
-            OutputStyle::Intel => writeln!(i, ".intel_syntax")?,
+            OutputStyle::Intel => {
+                if is_x86 {
+                    writeln!(i, ".intel_syntax")?
+                }
+            }
             OutputStyle::Att => {}
         };
 


### PR DESCRIPTION
`--mca` doesn't work on aarch64 macOS:

```
<stdin>:1:1: error: unknown directive
.intel_syntax
^
```

This PR disables the directive on other targets.

Perhaps a better solution would be to add another variant to `OutputStyle` instead, but the command-line parser is too clever to modify.
