### PR TITLE
mca analysis: only include .intel_syntax if original file had it

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
-use crate::asm::statements::{GenericDirective, Label};
+use crate::asm::statements::Label;
 use crate::cached_lines::CachedLines;
 use crate::demangle::LabelKind;
 use crate::{
@@ -12,7 +12,7 @@ mod statements;
 
 use owo_colors::OwoColorize;
 use statements::{parse_statement, Loc};
-pub use statements::{Directive, Instruction, Statement};
+pub use statements::{Directive, GenericDirective, Instruction, Statement};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Range;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,9 @@ pub trait Dumpable {
     /// Given a set of lines find all the interesting items
     fn find_items(lines: &[Self::Line<'_>]) -> BTreeMap<Item, Range<usize>>;
 
+    /// Initialize freshly created Dumpable using additional information from the file
+    fn init(&mut self, _lines: &[Self::Line<'_>]) {}
+
     /// print all the lines from this range, aplying the required formatting
     fn dump_range(&self, fmt: &Format, lines: &[Self::Line<'_>]) -> anyhow::Result<()>;
 
@@ -300,7 +303,7 @@ pub trait Dumpable {
 
 /// Parse a dumpable item from a file and dump it with all the extra context
 pub fn dump_function<T: Dumpable>(
-    dumpable: &T,
+    dumpable: &mut T,
     goal: ToDump,
     path: &Path,
     fmt: &Format,
@@ -312,6 +315,7 @@ pub fn dump_function<T: Dumpable>(
 
     let lines = T::split_lines(&contents)?;
     let items = T::find_items(&lines);
+    dumpable.init(&lines);
 
     match pick_dump_item(goal, fmt, &items) {
         Some(range) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,12 +190,12 @@ fn main() -> anyhow::Result<()> {
             match file.extension() {
                 Some(ext) if ext == "s" => {
                     let nope = PathBuf::new();
-                    let asm = Asm::new(&nope, &nope);
+                    let mut asm = Asm::new(&nope, &nope);
                     let mut format = opts.format;
                     // For standalone file we don't know the matching
                     // system root so don't even try to dump it
                     format.rust = false;
-                    dump_function(&asm, opts.to_dump, file, &format)?;
+                    dump_function(&mut asm, opts.to_dump, file, &format)?;
                 }
                 _ => {
                     #[cfg(feature = "disasm")]
@@ -295,21 +295,20 @@ fn main() -> anyhow::Result<()> {
 
     match opts.syntax.output_type {
         OutputType::Asm | OutputType::Wasm => {
-            let asm = Asm::new(metadata.workspace_root.as_std_path(), &sysroot);
-            dump_function(&asm, opts.to_dump, &asm_path, &opts.format)
+            let mut asm = Asm::new(metadata.workspace_root.as_std_path(), &sysroot);
+            dump_function(&mut asm, opts.to_dump, &asm_path, &opts.format)
         }
         OutputType::Llvm | OutputType::LlvmInput => {
-            dump_function(&Llvm, opts.to_dump, &asm_path, &opts.format)
+            dump_function(&mut Llvm, opts.to_dump, &asm_path, &opts.format)
         }
-        OutputType::Mir => dump_function(&Mir, opts.to_dump, &asm_path, &opts.format),
+        OutputType::Mir => dump_function(&mut Mir, opts.to_dump, &asm_path, &opts.format),
         OutputType::Mca => {
-            let mca = Mca::new(
+            let mut mca = Mca::new(
                 &opts.mca_arg,
-                opts.syntax.output_style,
                 cargo.target.as_deref(),
                 opts.target_cpu.as_deref(),
             );
-            dump_function(&mca, opts.to_dump, &asm_path, &opts.format)
+            dump_function(&mut mca, opts.to_dump, &asm_path, &opts.format)
         }
         #[cfg(not(feature = "disasm"))]
         OutputType::Disasm => no_disasm!(),

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -1,9 +1,4 @@
-use crate::{
-    asm::Statement,
-    demangle, esafeprintln,
-    opts::{Format, OutputStyle},
-    safeprintln, Dumpable,
-};
+use crate::{asm::Statement, demangle, esafeprintln, opts::Format, safeprintln, Dumpable};
 use std::{
     io::{BufRead, BufReader},
     process::{Command, Stdio},
@@ -12,22 +7,21 @@ use std::{
 pub struct Mca<'a> {
     /// mca specific arguments
     args: &'a [String],
-    output_style: OutputStyle,
     target_triple: Option<&'a str>,
     target_cpu: Option<&'a str>,
+    intel_syntax: bool,
 }
 impl<'a> Mca<'a> {
     pub fn new(
         mca_args: &'a [String],
-        output_style: OutputStyle,
         target_triple: Option<&'a str>,
         target_cpu: Option<&'a str>,
     ) -> Self {
         Self {
             args: mca_args,
-            output_style,
             target_triple,
             target_cpu,
+            intel_syntax: false,
         }
     }
 }
@@ -37,6 +31,18 @@ impl Dumpable for Mca<'_> {
 
     fn split_lines(contents: &str) -> anyhow::Result<Vec<Self::Line<'_>>> {
         crate::asm::parse_file(contents)
+    }
+
+    fn init(&mut self, lines: &[Self::Line<'_>]) {
+        use crate::asm::{Directive, GenericDirective, Statement};
+        for line in lines {
+            let Statement::Directive(Directive::Generic(GenericDirective(dir))) = line else {
+                return;
+            };
+            if dir.contains("intel_syntax") {
+                self.intel_syntax = true;
+            }
+        }
     }
 
     fn find_items(
@@ -73,11 +79,10 @@ impl Dumpable for Mca<'_> {
         let o = mca.stdout.take().expect("Stdout should be piped");
         let e = mca.stderr.take().expect("Stderr should be piped");
 
-        match self.output_style {
+        if self.intel_syntax {
             // without that llvm-mca gets confused for some instructions
-            OutputStyle::Intel => writeln!(i, ".intel_syntax")?,
-            OutputStyle::Att => {}
-        };
+            writeln!(i, ".intel_syntax")?
+        }
 
         for line in lines.iter() {
             match line {


### PR DESCRIPTION
An alternative approach to https://github.com/pacak/cargo-show-asm/pull/373, should remove the need to figure out what platforms support/require `.intel_syntax`