### PR TITLE
Release 0.2.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.47"
+version = "0.2.48"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.2.48] - unreleased
+- better support for ARM MCA and disassembly (#378) and (#375)
+  thanks @kornelski
+- default verbosity changes - (#377)
+- clippy improvements - (#376)
+
 ## [0.2.47] - 2025-01-21
 - don't try to override RUSTFLAGS unless needed - this should keep .config/cargo working (#364)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.2.48] - unreleased
+## [0.2.48] - 2025-02-22
 - better support for ARM MCA and disassembly (#378) and (#375)
   thanks @kornelski
 - default verbosity changes - (#377)


### PR DESCRIPTION
- better support for ARM MCA and disassembly (#378) and (#375)
  thanks @kornelski
- default verbosity changes - (#377)
- clippy improvements - (#376)