### PR TITLE
Release 0.2.49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.2.49] - 2025-04-06
+- Add a short alias `-F` in addition to `--features` (#390)
+  thanks @joseluis
+- try to support cursed combinations of forward and backward slashes
+  in file names created in case of crosscompilation (#382)
+
 ## [0.2.48] - 2025-02-22
 - better support for ARM MCA and disassembly (#378) and (#375)
   thanks @kornelski


### PR DESCRIPTION
- Add a short alias `-F` in addition to `--features` (#390)
  thanks @joseluis
- try to support cursed combinations of forward and backward slashes
  in file names created in case of crosscompilation (#382)