### PR TITLE
Display path:line together for clickable locations

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -329,15 +329,18 @@ fn dump_range(
             match files.get(&loc.file) {
                 Some((fname, Some((source, file)))) => {
                     if source.show_for(fmt.sources_from) {
-                        let rust_line = &file.get(loc.line as usize - 1).expect(
-                            "Corrupted rust-src installation? Try re-adding rust-src component.",
-                        );
                         let pos = format!("\t\t// {}:{}", fname.display(), loc.line);
                         safeprintln!("{}", color!(pos, OwoColorize::cyan));
-                        safeprintln!(
-                            "\t\t{}",
-                            color!(rust_line.trim_start(), OwoColorize::bright_red)
-                        );
+                        if let Some(rust_line) = &file.get(loc.line as usize - 1) {
+                            safeprintln!(
+                                "\t\t{}",
+                                color!(rust_line.trim_start(), OwoColorize::bright_red)
+                            );
+                        } else {
+                            safeprintln!("\t\t{}",
+                                color!("Corrupted rust-src installation? Try re-adding rust-src component.", OwoColorize::red)
+                            );
+                        }
                     }
                 }
                 Some((fname, None)) => {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -332,7 +332,7 @@ fn dump_range(
                         let rust_line = &file.get(loc.line as usize - 1).expect(
                             "Corrupted rust-src installation? Try re-adding rust-src component.",
                         );
-                        let pos = format!("\t\t// {} : {}", fname.display(), loc.line);
+                        let pos = format!("\t\t// {}:{}", fname.display(), loc.line);
                         safeprintln!("{}", color!(pos, OwoColorize::cyan));
                         safeprintln!(
                             "\t\t{}",
@@ -351,7 +351,7 @@ fn dump_range(
                             ),
                         );
                     }
-                    let pos = format!("\t\t// {} : {}", fname.display(), loc.line);
+                    let pos = format!("\t\t// {}:{}", fname.display(), loc.line);
                     safeprintln!("{}", color!(pos, OwoColorize::cyan));
                 }
                 None => {


### PR DESCRIPTION
`file:line` text without a space makes the path clickable in iTerm (and probably other terminals) and scrolls to the right line, which is super helpful.

I've also defused a panic that I ran into. When the program panics, I can't even see which lines are affected.