### PR TITLE
Release 0.2.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.49"
+version = "0.2.50"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.50] - 2025-06-18
+- Print links to rust sources as `file:line`, some terminals allow you to click them
+  thanks @kornelski
+- update deps
+
 ## [0.2.49] - 2025-04-06
 - Add a short alias `-F` in addition to `--features` (#390)
   thanks @joseluis


### PR DESCRIPTION
- Print links to rust sources as `file:line`, some terminals allow you to click them
  thanks @kornelski
- You can also render asm of dependencies using `-p` flag (0b3ffc9bba32f9fc3722b62b01dbbb8c47a0b4f0)
- update deps