### PR TITLE
Expand ~/ to home dir

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -572,10 +572,15 @@ fn load_rust_sources(
     fmt: &Format,
     files: &mut BTreeMap<u64, SourceFile>,
 ) {
+    let home_dir = std::env::home_dir();
+
     for line in statements {
         if let Statement::Directive(Directive::File(f)) = line {
             files.entry(f.index).or_insert_with(|| {
-                let path = f.path.as_full_path().into_owned();
+                let path = f
+                    .path
+                    .as_full_path_with_home_dir(home_dir.as_deref())
+                    .into_owned();
                 if fmt.verbosity > 2 {
                     safeprintln!("Reading file #{} {}", f.index, path.display());
                 }


### PR DESCRIPTION
I've added pretty-printing of `$HOME` as `~/` in the printed source code comments (when `--rust` is used).

It also prints relative paths when possible.

I'm rewriting my debug info paths to replace `/home/user/` with `~/`, but loading the sources requires expanding `~` back to a real path. I've added expansion to parsing of the paths.

