### PR TITLE
Explicit struct lifetimes

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -22,7 +22,7 @@ use std::path::{Display, Path, PathBuf};
 
 type SourceFile = (String, Option<(Source, CachedLines)>);
 
-pub fn parse_file(input: &str) -> anyhow::Result<Vec<Statement>> {
+pub fn parse_file(input: &str) -> anyhow::Result<Vec<Statement<'_>>> {
     // eat all statements until the eof, so we can report the proper errors on failed parse
     match nom::multi::many0(parse_statement).parse(input) {
         Ok(("", stmts)) => Ok(stmts),

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -169,7 +169,7 @@ pub fn find_items(lines: &[Statement]) -> BTreeMap<Item, Range<usize>> {
             let name_entry = names.entry(name.clone()).or_insert(0);
             res.insert(
                 Item {
-                    mangled_name: sym.to_string(),
+                    mangled_name: (*sym).to_string(),
                     name,
                     hashed,
                     index: *name_entry,
@@ -505,13 +505,13 @@ fn locate_sources(sysroot: &Path, workspace: &Path, path: &Path) -> Option<(Sour
         && path
             .as_os_str()
             .to_str()
-            .is_some_and(|s| s.contains("\\") && s.contains("/"))
+            .is_some_and(|s| s.contains('\\') && s.contains('/'))
     {
         let cursed_path = path
             .as_os_str()
             .to_str()
             .expect("They are coming from a text file");
-        path = Cow::Owned(PathBuf::from(cursed_path.replace("\\", "/")));
+        path = Cow::Owned(PathBuf::from(cursed_path.replace('\\', "/")));
     }
 
     // /rustc/89e2160c4ca5808657ed55392620ed1dbbce78d1/compiler/rustc_span/src/span_encoding.rs
@@ -689,7 +689,7 @@ impl Dumpable for Asm<'_> {
         }
 
         if fmt.include_constants {
-            let print_range = URange::from(range.clone());
+            let print_range = URange::from(range);
             // scan for referenced constants such as strings, scan needs to be done recursively
             let mut pending = vec![print_range];
             let mut seen: BTreeSet<URange> = BTreeSet::new();

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -779,7 +779,7 @@ fn parse_function_alias() {
     assert_eq!(
         parse_statement(".set\ttwo,\tone_plus_one\n").unwrap().1,
         Statement::Directive(Directive::SetValue("two", "one_plus_one"))
-    )
+    );
 }
 
 #[test]

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -51,7 +51,7 @@ impl<'a> Instruction<'a> {
     }
 }
 
-fn parse_data_dec(input: &str) -> IResult<&str, Directive> {
+fn parse_data_dec(input: &str) -> IResult<&str, Directive<'_>> {
     static DATA_DEC: OnceLock<Regex> = OnceLock::new();
     // all of those can insert something as well... Not sure if it's a full list or not
     // .long, .short .octa, .quad, .word,
@@ -814,7 +814,7 @@ pub enum Directive<'a> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GenericDirective<'a>(pub &'a str);
 
-pub fn parse_statement(input: &str) -> IResult<&str, Statement> {
+pub fn parse_statement(input: &str) -> IResult<&str, Statement<'_>> {
     let label = map(Label::parse, Statement::Label);
 
     let file = map(File::parse, Directive::File);

--- a/src/cached_lines.rs
+++ b/src/cached_lines.rs
@@ -14,7 +14,7 @@ impl CachedLines {
     }
 
     #[must_use]
-    pub fn iter(&self) -> LineIter {
+    pub fn iter(&self) -> LineIter<'_> {
         LineIter {
             payload: self,
             current: 0,

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -13,7 +13,7 @@ pub fn name(input: &str) -> Option<String> {
 }
 
 #[must_use]
-pub fn demangled(input: &str) -> Option<Demangle> {
+pub fn demangled(input: &str) -> Option<Demangle<'_>> {
     let name = if input.starts_with("__") {
         #[allow(clippy::string_slice)]
         rustc_demangle::try_demangle(&input[1..]).ok()?

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -39,8 +39,8 @@ impl std::fmt::Display for HexDump<'_> {
         if self.bytes.is_empty() {
             return Ok(());
         }
-        for byte in self.bytes.iter() {
-            write!(f, "{:02x} ", byte)?;
+        for byte in self.bytes {
+            write!(f, "{byte:02x} ")?;
         }
         for _ in 0..(1 + self.max_width - self.bytes.len()) {
             f.write_str("   ")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ pub fn dump_function<T: Dumpable>(
                 // for asm files extra_context loads rust sources
                 T::extra_context(dumpable, fmt, &lines, 0..lines.len(), &items);
             }
-            dumpable.dump_range(fmt, &lines)?
+            dumpable.dump_range(fmt, &lines)?;
         }
     }
     Ok(())

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -77,7 +77,7 @@ impl Dumpable for Llvm {
                         },
                         start: ix,
                     });
-                    cur.item.mangled_name = name.to_owned();
+                    name.clone_into(&mut cur.item.mangled_name);
                     cur.item.hashed = demangle::demangled(name)
                         .map_or_else(|| name.to_owned(), |hashed| format!("{hashed:?}"));
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn main() -> anyhow::Result<()> {
                 _ => {
                     #[cfg(feature = "disasm")]
                     {
-                        dump_disasm(opts.to_dump, file, &opts.format, opts.syntax.output_style)?
+                        dump_disasm(opts.to_dump, file, &opts.format, opts.syntax.output_style)?;
                     }
                     #[cfg(not(feature = "disasm"))]
                     {

--- a/src/mca.rs
+++ b/src/mca.rs
@@ -81,10 +81,10 @@ impl Dumpable for Mca<'_> {
 
         if self.intel_syntax {
             // without that llvm-mca gets confused for some instructions
-            writeln!(i, ".intel_syntax")?
+            writeln!(i, ".intel_syntax")?;
         }
 
-        for line in lines.iter() {
+        for line in lines {
             match line {
                 Statement::Label(l) => writeln!(i, "{}:", l.id)?,
                 Statement::Directive(_) => {}


### PR DESCRIPTION
Rust started warning about `mismatched_lifetime_syntaxes`. I've also applied a few other clippy lints.