### PR TITLE
Release 0.2.52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.51"
+version = "0.2.52"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.51"
+version = "0.2.52"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.52] - 2025-08-10
+- Various codebase improvements and support for unstable cargo `build-dir`
+  thanks @kornelski
+- bump deps
+
 ## [0.2.51] - 2025-06-29
 - Use ~ in place of home dir and relative paths for current project when printing rust source code
   for both privacy and convenience


### PR DESCRIPTION
- support for `cargo` `build-dir` (#409)