### PR TITLE
Release 0.2.53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.52"
+version = "0.2.53"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.53] - 2025-10-28
+- `--disasm` support for m68k, RISC-V (32- and 64-bit) and x32
+  thanks @cabalorguk
+- bump deps
+
 ## [0.2.52] - 2025-08-10
 - Various codebase improvements and support for unstable cargo `build-dir`
   thanks @kornelski


### PR DESCRIPTION
- `--disasm` support for m68k, RISC-V (32- and 64-bit) and x32 
  thanks @cabalorguk
- bump deps