### PR TITLE
Improve label/comment parsing

### DIFF
--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -538,9 +538,7 @@ fn test_parse_label() {
         ))
     );
     assert_eq!(
-        Label::parse(
-            ".Ltmp0:\t# comment"
-        ),
+        Label::parse(".Ltmp0:\t# comment"),
         Ok((
             "",
             Label {


### PR DESCRIPTION
Ran into an issue while working with the `riscv-rt` and/or `semihosting` crates (didn't track down specifically), but the issue was parsing generated asm with a label and a comment on the same line.

`cargo asm` output:

```
Error: Didn't consume everything, leftovers prefix: ".Ltmp0:\t# to prevent an unsupported R_RISCV_ALIGN relocation from being generated\n\tauipc\tra, %pcrel_hi(.Ltmp1)\n\tld\tra, %pcrel_lo(.Ltmp0)(ra)\n\tret\n\t.p2align\t3\n.Ltmp1:\n\t.quad\t_abs_start\n\t.option\tpop\n\n_a"
```

Seems like a legal syntax to me so I went ahead and tracked it down here.