### PR TITLE
Release 0.2.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.53"
+version = "0.2.54"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.54] - 2025-11-03
+- improve label/comment parsing (#425)
+  thanks @guncha
+- support new merged function representation since 1.91.0 (#426)
+
 ## [0.2.53] - 2025-10-28
 - `--disasm` support for m68k, RISC-V (32- and 64-bit) and x32
   thanks @cabalorguk


### PR DESCRIPTION
- improve label/comment parsing (#425)
  thanks @guncha
- support new merged function representation since 1.91.0 (#426)