### PR TITLE
Release 0.2.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.54"
+version = "0.2.55"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.55] - 2025-12-01
+- support execution from subdirectories as well, similar to other cargo commands (#430)
+- bump deps
+
+
 ## [0.2.54] - 2025-11-03
 - improve label/comment parsing (#425)
   thanks @guncha


### PR DESCRIPTION
- support execution from subdirectories as well, similar to other cargo commands (#430)
- bump deps

