### PR TITLE
Fix unnecessary #[allow(clippy::range_plus_one)]

### DIFF
--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -87,8 +87,6 @@ impl Dumpable for Llvm {
                 }
             } else if line == "}" {
                 if let Some(mut cur) = current_item.take() {
-                    // go home clippy, you're drunk
-                    #[allow(clippy::range_plus_one)]
                     let range = cur.start..ix + 1;
                     cur.item.len = range.len();
                     res.insert(cur.item, range);

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -21,8 +21,6 @@ impl Dumpable for Mir {
                 }
             } else if line == "}" {
                 if let Some(mut cur) = current_item.take() {
-                    // go home clippy, you're drunk
-                    #[allow(clippy::range_plus_one)]
                     let range = cur.len..ix + 1;
                     cur.len = range.len();
                     res.insert(cur, range);


### PR DESCRIPTION
This lint now works correctly https://github.com/rust-lang/rust-clippy/issues/3307.