### PR TITLE
Release 2.5.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.57"
+version = "0.2.58"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.2.58] - 2026-05-21
+- a bunch of small optimizations, but it should run 60%ish faster now
+- a bunch more small improvements in general - less unwraps, better
+  error messages if something can happen in theory.
+- a redundant allow(clippy) removal - clippy is smarter now
+  thanks @alexander-t-haselton
+- bump deps (as usual)
+
 ## [0.2.57] - 2026-03-13
 - More support for cargo build-dir (#449)
   thanks @ranger-ross

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -364,7 +364,7 @@ fn dump_range(
                     safeprintln!("{}", color!(pos, OwoColorize::cyan));
                 }
                 None => {
-                    panic!("DWARF file refers to an undefined location {loc:?}");
+                    anyhow::bail!("DWARF file refers to an undefined location {loc:?}");
                 }
             }
             empty_line = false;

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -374,8 +374,8 @@ fn dump_range(
         }) = line
         {
             match fmt.redundant_labels {
-                // We always include used labels and labels at the very
-                // beginning of the fragment - those are used for data declarations
+                // We always include used labels and labels at the start
+                // of the fragment - those are used for data declarations
                 _ if ix == 0 || used.contains(id) => {
                     safeprintln!("{line}");
                 }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -229,10 +229,6 @@ fn handle_non_mangled_labels(
                 get_item_in_section(ix, label, ss.strip_prefix(".text.")?, false)
             }
         }
-        //        Some(Statement::Directive(Directive::Generic(GenericDirective(g)))) => {
-        // macOS symbols after the first are matched here.
-        //            get_item_in_section(PrefixKind::Global, ix, label, g, true)
-        //        }
         Some(Statement::Directive(Directive::Global(g))) => get_item_in_section(ix, label, g, true),
         _ => None,
     }

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use nom::branch::alt;
 use nom::bytes::complete::{escaped_transform, tag, take_while1, take_while_m_n};
@@ -54,15 +54,14 @@ impl<'a> Instruction<'a> {
 }
 
 fn parse_data_dec(input: &str) -> IResult<&str, Directive<'_>> {
-    static DATA_DEC: OnceLock<Regex> = OnceLock::new();
-    // all of those can insert something as well... Not sure if it's a full list or not
-    // .long, .short .octa, .quad, .word,
-    // .single .double .float
-    // .ascii, .asciz, .string, .string8 .string16 .string32 .string64
-    // .2byte .4byte .8byte
-    // .dc
-    // .inst .insn
-    let reg = DATA_DEC.get_or_init(|| {
+    static DATA_DEC: LazyLock<Regex> = LazyLock::new(|| {
+        // all of those can insert something as well... Not sure if it's a full list or not
+        // .long, .short .octa, .quad, .word,
+        // .single .double .float
+        // .ascii, .asciz, .string, .string8 .string16 .string32 .string64
+        // .2byte .4byte .8byte
+        // .dc
+        // .inst .insn
         // regexp is inspired by the compiler explorer
         Regex::new(
             "^\\s*\\.(ascii|asciz|[1248]?byte|dc(?:\\.[abdlswx])?|dcb(?:\\.[bdlswx])?\
@@ -72,7 +71,7 @@ fn parse_data_dec(input: &str) -> IResult<&str, Directive<'_>> {
         .expect("regexp should be valid")
     });
 
-    let Some(cap) = reg.captures(input) else {
+    let Some(cap) = DATA_DEC.captures(input) else {
         use nom::error::*;
         return Err(nom::Err::Error(Error::new(input, ErrorKind::Eof)));
     };

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -1,7 +1,3 @@
-use std::borrow::Cow;
-use std::path::Path;
-use std::sync::LazyLock;
-
 use nom::branch::alt;
 use nom::bytes::complete::{escaped_transform, tag, take_while1, take_while_m_n};
 use nom::character::complete::{self, newline, none_of, not_line_ending, one_of, space0, space1};
@@ -10,7 +6,10 @@ use nom::multi::count;
 use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::{AsChar, IResult, Parser as _};
 use owo_colors::OwoColorize;
-use regex::Regex;
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::demangle::LabelKind;
 use crate::opts::NameDisplay;
@@ -53,35 +52,52 @@ impl<'a> Instruction<'a> {
     }
 }
 
-fn parse_data_dec(input: &str) -> IResult<&str, Directive<'_>> {
-    static DATA_DEC: LazyLock<Regex> = LazyLock::new(|| {
-        // all of those can insert something as well... Not sure if it's a full list or not
-        // .long, .short .octa, .quad, .word,
-        // .single .double .float
-        // .ascii, .asciz, .string, .string8 .string16 .string32 .string64
-        // .2byte .4byte .8byte
-        // .dc
-        // .inst .insn
-        // regexp is inspired by the compiler explorer
-        Regex::new(
-            "^\\s*\\.(ascii|asciz|[1248]?byte|dc(?:\\.[abdlswx])?|dcb(?:\\.[bdlswx])?\
-            |ds(?:\\.[bdlpswx])?|double|dword|fill|float|half|hword|int|long|octa|quad|\
-            short|single|skip|space|string(?:8|16|32|64)?|value|word|xword|zero)\\s+([^\\n]+)",
-        )
-        .expect("regexp should be valid")
-    });
+// All data directive names the original regex matched
+static DATA_DIRS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
+    // all of those can insert something as well... Not sure if it's a full list or not
+    // .long, .short .octa, .quad, .word,
+    // .single .double .float
+    // .ascii, .asciz, .string, .string8 .string16 .string32 .string64
+    // .2byte .4byte .8byte
+    // .dc
+    // .inst .insn
 
-    let Some(cap) = DATA_DEC.captures(input) else {
+    [
+        "string64", "string32", "string16", "string8", "dcb.x", "dcb.w", "dcb.s", "dcb.l", "dcb.d",
+        "dcb.b", "ds.x", "ds.w", "ds.s", "ds.p", "ds.l", "ds.d", "ds.b", "dc.x", "dc.w", "dc.s",
+        "dc.l", "dc.d", "dc.a", "dc.b", "8byte", "4byte", "2byte", "byte", "xword", "value",
+        "zero", "word", "skip", "single", "string", "space", "short", "quad", "octa", "long",
+        "int", "hword", "half", "float", "fill", "dword", "double", "dc", "ds", "dcb", "asciz",
+        "ascii",
+    ]
+    .into_iter()
+    .collect()
+});
+
+fn parse_data_dec(input: &str) -> IResult<&str, Directive<'_>> {
+    let trimmed = input.trim_start();
+    let Some(rest) = trimmed.strip_prefix('.') else {
         use nom::error::*;
         return Err(nom::Err::Error(Error::new(input, ErrorKind::Eof)));
     };
-    let (Some(instr), Some(data)) = (cap.get(1), cap.get(2)) else {
-        panic!("regexp should be valid and capture found something");
-    };
-    Ok((
-        &input[data.range().end..],
-        Directive::Data(instr.as_str(), data.as_str()),
-    ))
+
+    let word_end = rest.find([' ', '\t']).unwrap_or(rest.len());
+    let directive = &rest[..word_end];
+
+    if !DATA_DIRS.contains(&directive) {
+        use nom::error::*;
+        return Err(nom::Err::Error(Error::new(input, ErrorKind::Eof)));
+    }
+
+    let after_directive = &rest[word_end..];
+    let after_ws = after_directive.trim_start();
+    let data_end = after_ws.find('\n').unwrap_or(after_ws.len());
+    let data = &after_ws[..data_end];
+
+    let leading_ws = input.len() - trimmed.len();
+    let consumed = leading_ws + 1 + rest.len() - after_ws.len() + data.len();
+
+    Ok((&input[consumed..], Directive::Data(directive, data)))
 }
 
 impl Statement<'_> {

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -3,7 +3,7 @@
 
 use crate::{color, opts::NameDisplay};
 use owo_colors::OwoColorize;
-use regex::{Regex, RegexSet, Replacer};
+use regex::{Regex, Replacer};
 use rustc_demangle::Demangle;
 use std::{borrow::Cow, sync::LazyLock};
 
@@ -42,9 +42,6 @@ pub(self) const GLOBAL_LABELS_REGEX: &str = r"\b_?(_[a-zA-Z0-9_$\.]+)";
 // Note: this rejects "labels" like `H.Lfoo` but accepts `.Lexception` and `[some + .Label]`
 pub(self) const LOCAL_LABELS_REGEX: &str = r"(?:[^\w\d\$\.]|^)(\.L[a-zA-Z0-9_\$\.]+|\bLBB[0-9_]+)";
 
-// temporary labels
-pub(self) const TEMP_LABELS_REGEX: &str = r"\b(Ltmp[0-9]+)\b";
-
 pub(self) fn global_labels_reg() -> &'static Regex {
     static GLOBAL_LABELS: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));
@@ -55,14 +52,6 @@ pub(self) fn local_labels_reg() -> &'static Regex {
     static LOCAL_LABELS: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(LOCAL_LABELS_REGEX).expect("regexp should be valid"));
     &LOCAL_LABELS
-}
-
-pub(self) fn label_kinds_reg() -> &'static RegexSet {
-    static LABEL_KINDS: LazyLock<RegexSet> = LazyLock::new(|| {
-        RegexSet::new([LOCAL_LABELS_REGEX, GLOBAL_LABELS_REGEX, TEMP_LABELS_REGEX])
-            .expect("regexp should be valid")
-    });
-    &LABEL_KINDS
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,11 +82,17 @@ pub(crate) fn local_labels(input: &str) -> impl Iterator<Item = &str> {
 
 #[must_use]
 pub fn label_kind(input: &str) -> LabelKind {
-    match label_kinds_reg().matches(input).into_iter().next() {
-        Some(1) => LabelKind::Global,
-        Some(0) => LabelKind::Local,
-        Some(2) => LabelKind::Temp,
-        _ => LabelKind::Unknown,
+    if input.starts_with(".L") || input.starts_with("LBB") {
+        // Local labels: .L... or LBB...
+        LabelKind::Local
+    } else if input.starts_with("Ltmp") {
+        // Temp labels: LtmpN
+        LabelKind::Temp
+    } else if input.starts_with('_') {
+        // Global labels: start with _ (but not .L or LBB which are local)
+        LabelKind::Global
+    } else {
+        LabelKind::Unknown
     }
 }
 

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -14,13 +14,15 @@ pub fn name(input: &str) -> Option<String> {
 
 #[must_use]
 pub fn demangled(input: &str) -> Option<Demangle<'_>> {
-    let name = if input.starts_with("__") {
-        #[allow(clippy::string_slice)]
-        rustc_demangle::try_demangle(&input[1..]).ok()?
+    // Skip expensive demangling for labels that clearly aren't Rust mangled names (e.g.,
+    // .Lfunc_begin0, .LBB0_0, .LCPI0_0, etc.)
+    if !input.starts_with("_") {
+        None
+    } else if input.starts_with("__") {
+        rustc_demangle::try_demangle(&input[1..]).ok()
     } else {
-        rustc_demangle::try_demangle(input).ok()?
-    };
-    Some(name)
+        rustc_demangle::try_demangle(input).ok()
+    }
 }
 
 pub(self) const GLOBAL_LABELS_REGEX: &str = r"\b_?(_[a-zA-Z0-9_$\.]+)";

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -5,7 +5,7 @@ use crate::{color, opts::NameDisplay};
 use owo_colors::OwoColorize;
 use regex::{Regex, RegexSet, Replacer};
 use rustc_demangle::Demangle;
-use std::{borrow::Cow, sync::OnceLock};
+use std::{borrow::Cow, sync::LazyLock};
 
 #[must_use]
 pub fn name(input: &str) -> Option<String> {
@@ -44,21 +44,23 @@ pub(self) const LOCAL_LABELS_REGEX: &str = r"(?:[^\w\d\$\.]|^)(\.L[a-zA-Z0-9_\$\
 pub(self) const TEMP_LABELS_REGEX: &str = r"\b(Ltmp[0-9]+)\b";
 
 pub(self) fn global_labels_reg() -> &'static Regex {
-    static GLOBAL_LABELS: OnceLock<Regex> = OnceLock::new();
-    GLOBAL_LABELS.get_or_init(|| Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"))
+    static GLOBAL_LABELS: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(GLOBAL_LABELS_REGEX).expect("regexp should be valid"));
+    &GLOBAL_LABELS
 }
 
 pub(self) fn local_labels_reg() -> &'static Regex {
-    static LOCAL_LABELS: OnceLock<Regex> = OnceLock::new();
-    LOCAL_LABELS.get_or_init(|| Regex::new(LOCAL_LABELS_REGEX).expect("regexp should be valid"))
+    static LOCAL_LABELS: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(LOCAL_LABELS_REGEX).expect("regexp should be valid"));
+    &LOCAL_LABELS
 }
 
 pub(self) fn label_kinds_reg() -> &'static RegexSet {
-    static LABEL_KINDS: OnceLock<RegexSet> = OnceLock::new();
-    LABEL_KINDS.get_or_init(|| {
+    static LABEL_KINDS: LazyLock<RegexSet> = LazyLock::new(|| {
         RegexSet::new([LOCAL_LABELS_REGEX, GLOBAL_LABELS_REGEX, TEMP_LABELS_REGEX])
             .expect("regexp should be valid")
-    })
+    });
+    &LABEL_KINDS
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -227,7 +227,7 @@ fn dump_slices(
 
     let max_width = insns.iter().map(|i| i.len()).max().unwrap_or(1);
 
-    // flow control related addresses referred by each instruction
+    // branch target addresses for local labels
     let addrs = insns
         .iter()
         .map(|insn| {
@@ -238,8 +238,8 @@ fn dump_slices(
                     .iter()
                     .any(|g| matches!(cs.group_name(*g).as_deref(), Some("call" | "jump")))
             }) {
-                let r = get_reference(&cs, insn)?;
-                (r != insn.address() + insn.len() as u64).then_some(r)
+                get_branch_target(&cs, insn)
+                    .filter(|addr| *addr != insn.address() + insn.len() as u64)
             } else {
                 None
             }
@@ -314,7 +314,12 @@ fn dump_slices(
     Ok(())
 }
 
-fn get_reference(cs: &Capstone, insn: &Insn) -> Option<u64> {
+/// Extract the target address from a call/jump instruction with an immediate operand.
+///
+/// Returns `None` for indirect branches (through memory or registers) since their
+/// targets can't be resolved at disassembly time. GOT calls like `jmp [rip]` are
+/// resolved via relocation instead.
+fn get_branch_target(cs: &Capstone, insn: &Insn) -> Option<u64> {
     use capstone::arch::{
         arm64::Arm64OperandType, x86::X86OperandType, ArchDetail, DetailsArchInsn,
     };
@@ -322,28 +327,12 @@ fn get_reference(cs: &Capstone, insn: &Insn) -> Option<u64> {
     match details.arch_detail() {
         ArchDetail::X86Detail(x86) => match x86.operands().next()?.op_type {
             X86OperandType::Imm(rel) => Some(rel.try_into().unwrap()),
-            X86OperandType::Mem(mem) => {
-                assert_eq!(mem.scale(), 1);
-                if mem.disp() == 0 {
-                    (insn.address() + insn.len() as u64).checked_add_signed(mem.disp())
-                } else {
-                    None
-                }
-            }
-            _ => None, // ¯\_ (ツ)_/¯
+            _ => None,
         },
 
-        // I have no idea what I'm doing here :)
         ArchDetail::Arm64Detail(arm) => match arm.operands().next()?.op_type {
             Arm64OperandType::Imm(rel) => Some(rel.try_into().unwrap()),
-            Arm64OperandType::Mem(mem) => {
-                if mem.disp() == 0 {
-                    (insn.address() + insn.len() as u64).checked_add_signed(mem.disp() as i64)
-                } else {
-                    None
-                }
-            }
-            _ => None, // ¯\_ (ツ)_/¯
+            _ => None,
         },
 
         _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub fn suggest_name<'a>(
 
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_precision_loss)]
-    let width = (count as f64).log10().ceil() as usize;
+    let width = (count.max(1) as f64).log10().ceil() as usize;
 
     let mut ix = 0;
     for (name, lens) in &names {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,19 +16,19 @@ use std::{
     io::BufReader,
     path::{Path, PathBuf},
     process::{Child, Stdio},
-    sync::OnceLock,
+    sync::LazyLock,
 };
 
 fn cargo_path() -> &'static Path {
-    static CARGO_PATH: OnceLock<PathBuf> = OnceLock::new();
-    CARGO_PATH
-        .get_or_init(|| std::env::var_os("CARGO").map_or_else(|| "cargo".into(), PathBuf::from))
+    static CARGO_PATH: LazyLock<PathBuf> =
+        LazyLock::new(|| std::env::var_os("CARGO").map_or_else(|| "cargo".into(), PathBuf::from));
+    &CARGO_PATH
 }
 
 fn rust_path() -> &'static Path {
-    static RUSTC_PATH: OnceLock<PathBuf> = OnceLock::new();
-    RUSTC_PATH
-        .get_or_init(|| std::env::var_os("RUSTC").map_or_else(|| "rustc".into(), PathBuf::from))
+    static RUSTC_PATH: LazyLock<PathBuf> =
+        LazyLock::new(|| std::env::var_os("RUSTC").map_or_else(|| "rustc".into(), PathBuf::from));
+    &RUSTC_PATH
 }
 
 #[cfg(not(feature = "disasm"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,6 +658,11 @@ fn read_dir_recursive(path: &Path, build_dir: &impl Fn(&Path) -> PathBuf) -> Vec
         .collect()
 }
 
+/// Check if files have the same contents
+///
+/// Before that we check if they are the same according to hardlinks (sorry filesystems with no
+/// hardlinks, you are not real), and before reading files - we check if sizes are the same - files
+/// are likely identical.
 fn same_contents(a: &Path, b: &Path) -> bool {
     same_file::is_same_file(a, b).unwrap_or(false)
         || (std::fs::metadata(a)

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,10 @@ fn cargo_to_asm_path(
             {
                 rlib.into()
             } else {
-                todo!("{:?}", artifact);
+                anyhow::bail!(
+                    "Looking for an executable or an rlib file to work on, got {:?} instead.",
+                    artifact
+                );
             }
         }
     };

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -513,8 +513,7 @@ impl Focus {
         let (kind, name) = self.as_parts();
         let somewhat_matches =
             kind == "lib" && artifact.target.is_rlib() || artifact.target.is_cdylib();
-        let kind = <cargo_metadata::TargetKind as std::str::FromStr>::from_str(kind)
-            .expect("cargo_metadata made me do it");
+        let Ok(kind) = <cargo_metadata::TargetKind as std::str::FromStr>::from_str(kind);
         let kind_matches = artifact.target.kind.contains(&kind);
         (somewhat_matches || kind_matches) && name.is_none_or(|name| artifact.target.name == *name)
     }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -6,7 +6,7 @@ fn check_target_dir(path: PathBuf) -> anyhow::Result<PathBuf> {
     if path.is_dir() {
         Ok(path)
     } else {
-        std::fs::create_dir(&path)?;
+        std::fs::create_dir_all(&path)?;
         Ok(std::fs::canonicalize(path)?)
     }
 }


### PR DESCRIPTION
- a bunch of small optimizations, but it should run 60%ish faster now
- a bunch more small improvements in general - less unwraps, better
  error messages if something can happen in theory.
- a redundant allow(clippy) removal - clippy is smarter now
  thanks @alexander-t-haselton
- bump deps (as usual)