### PR TITLE
Release 0.2.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.58"
+version = "0.2.59"
 edition = "2021"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## [0.2.58] - 2026-05-21
+## [0.2.59] - 2026-05-02
+- support for instructions with '+' in it (#460)
+- bump deps
+
+## [0.2.58] - 2026-04-21
 - a bunch of small optimizations, but it should run 60%ish faster now
 - a bunch more small improvements in general - less unwraps, better
   error messages if something can happen in theory.

--- a/src/asm/statements.rs
+++ b/src/asm/statements.rs
@@ -45,8 +45,8 @@ impl<'a> Instruction<'a> {
     fn parse_regular(input: &'a str) -> IResult<&'a str, Self> {
         // NOTE: ARM allows `.` inside instruction names e.g. `b.ne` for branch not equal
         //       Wasm also uses `.` in instr names, and uses `_` for `end_function`
-        //       "powerpc-nintendo-none-eabi.json" uses `-` in `blt-`...
-        let op = take_while1(|c| AsChar::is_alphanum(c) || matches!(c, '.' | '_' | '-'));
+        //       "powerpc-nintendo-none-eabi.json" uses `+` and `-` in `blt-`/`blt+`...
+        let op = take_while1(|c| AsChar::is_alphanum(c) || matches!(c, '.' | '_' | '-' | '+'));
         let args = opt(preceded(space1, not_line_ending));
         map(pair(op, args), |(op, args)| Instruction { op, args }).parse(input)
     }


### PR DESCRIPTION
- support for instructions with '+' in it (Fixes #460)
- bump deps