### PR TITLE
chore: add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-show-asm"
 version = "0.2.59"
 edition = "2021"
+rust-version = "1.86"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."
 categories = ["development-tools::cargo-plugins", "development-tools::debugging"]
 keywords = ["assembly", "plugins", "cargo"]


### PR DESCRIPTION
cargo_metadata@0.23.1 requires rustc 1.86.0