### PR TITLE
Remove package.authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ categories = ["development-tools::cargo-plugins", "development-tools::debugging"
 keywords = ["assembly", "plugins", "cargo"]
 repository = "https://github.com/pacak/cargo-show-asm"
 homepage = "https://github.com/pacak/cargo-show-asm"
-authors = ["Michael Baykov <manpacket@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068