### PR TITLE
clippy: fix items_after_statements lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = [
 
 [workspace.lints.clippy]
 if_not_else = "warn"
+items_after_statements = "warn"
 
 [workspace.metadata.cauwugo]
 bpaf = true

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -13,6 +13,7 @@ use object::{
 use owo_colors::OwoColorize;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Write as _,
     path::Path,
 };
 
@@ -290,7 +291,6 @@ fn dump_slices(
 
         if let Some(id) = maddr.and_then(|a| local_labels.get(&a)) {
             buf.clear();
-            use std::fmt::Write;
             write!(
                 buf,
                 "{}{}",


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#items_after_statements