### PR TITLE
Release 0.2.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.59"
+version = "0.2.60"
 edition = "2024"
 rust-version = "1.86"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## [0.2.60] - unreleased
+## [0.2.60] - 2026-05-29
 - misc improvements by @xtqqczze and myself
-- list found items as json with `--json`, useful for scripting and CI
+- list found items as JSON with `--json`, useful for scripting and CI
+- filter by called functions (`--callers-of NAME [DEPTH]`)
 
 ## [0.2.59] - 2026-05-02
 - support for instructions with '+' in it (#460)

--- a/README.md
+++ b/README.md
@@ -281,10 +281,13 @@ cargo asm --lib --callers-of panic
 ```
 
 `--callers-of` takes one required parameter - a regexp pattern of a function
-and one optional - how deep that call might be: `--callers-of panic 0` will
-list only functions that have "panic" in their own name, `--callers-of panic 1`
-- this adds any functions that call functions with "panic" in their name (this
-includes any panics from `core`).
+and one optional - how deep that call might be:
+
+- `--callers-of panic 0` - will list only functions that have "panic" in their
+  own name.
+
+- `--callers-of panic 1` - this adds any functions that call functions with
+  "panic" in their name (this includes any panics from `core`).
 
 # JSON output
 

--- a/README.tpl
+++ b/README.tpl
@@ -87,10 +87,13 @@ cargo asm --lib --callers-of panic
 ```
 
 `--callers-of` takes one required parameter - a regexp pattern of a function
-and one optional - how deep that call might be: `--callers-of panic 0` will
-list only functions that have "panic" in their own name, `--callers-of panic 1`
-- this adds any functions that call functions with "panic" in their name (this
-includes any panics from `core`).
+and one optional - how deep that call might be:
+
+- `--callers-of panic 0` - will list only functions that have "panic" in their
+  own name.
+
+- `--callers-of panic 1` - this adds any functions that call functions with
+  "panic" in their name (this includes any panics from `core`).
 
 # JSON output
 


### PR DESCRIPTION
- list found items as JSON with `--json`, useful for scripting and CI (#473)
- call graph filtering (`--callers-of NAME [DEPTH]`) (#476)
- misc improvements by @xtqqczze and myself

# Call graph filtering

By default `cargo-show-asm` lists all the functions. You can limit it to all the functions that
call some other function - by name pattern. Can be useful if you find to list all the functions
that can panic you can type something like this:

```console,ignore
cargo asm --lib --callers-of panic
```

`--callers-of` takes one required parameter - a regexp pattern of a function
and one optional - how deep that call might be:

- `--callers-of panic 0` - will list only functions that have "panic" in their
  own name.

- `--callers-of panic 1` - this adds any functions that call functions with
  "panic" in their name (this includes any panics from `core`).