### PR TITLE
Release 0.2.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.60"
+version = "0.2.61"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.60"
+version = "0.2.61"
 edition = "2024"
 rust-version = "1.86"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.61] - 2026-06-10
+- use full package ID (`id.repr`)  when passing `--package` to `cargo` (#478)
+
 ## [0.2.60] - 2026-05-29
 - misc improvements by @xtqqczze and myself
 - list found items as JSON with `--json`, useful for scripting and CI

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn spawn_cargo(
         )
         .args(["--config", "profile.release.strip=false"])
         // Artifact selectors.
-        .args(["--package", &focus_package.name])
+        .args(["--package", &focus_package.id.repr])
         .args(focus_artifact.as_cargo_args())
         // Compile options.
         .args(cargo.config.iter().flat_map(|c| ["--config", c]))


### PR DESCRIPTION

Use full package ID (`id.repr`)  when passing `--package` to `cargo` (Fixes #478)