### PR TITLE
Improve function matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo install cargo-show-asm
 
 Show the code rustc generates for any function
 
-**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`-c`**=_`COUNT`_\] \[**`--simplify`**\] \[**`--include-constants`**\] \[**`--json`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] _`OUTPUT-FORMAT`_ \[**`--callers-of`** _`REGEX`_ \[_`DEPTH`_\]\] \[**`--everything`** | _`FUNCTION`_ \[_`INDEX`_\]\]
+**Usage**: **`cargo asm`** \[**`-p`**=_`SPEC`_\] \[_`ARTIFACT`_\] \[**`-M`**=_`ARG`_\]... \[_`TARGET-CPU`_\] \[**`--rust`**\] \[**`-c`**=_`COUNT`_\] \[**`--simplify`**\] \[**`--include-constants`**\] \[**`--json`**\] \[**`--this-workspace`** | **`--all-crates`** | **`--all-sources`**\] _`OUTPUT-FORMAT`_ \[**`--callers-of`** _`REGEX`_ \[_`DEPTH`_\]\] (**`--everything`** | \[_`FUNCTION`_\]... \[_`INDEX`_\])
 
  Usage:
  1. Focus on a single assembly producing target:
@@ -193,7 +193,7 @@ Show the code rustc generates for any function
 - **`    --everything`** &mdash; 
   Dump the whole file
 - _`FUNCTION`_ &mdash; 
-  Dump a function with a given name, filter functions by name
+  Dump a function with a given name, filter functions by name, multiple filters can be specified, all must match
 - _`INDEX`_ &mdash; 
   Select specific function when there's several with the same name
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ fn format_items_json<'a>(items: impl IntoIterator<Item = &'a Item>) -> String {
 }
 
 pub fn suggest_name<'a>(
-    search: &str,
+    search_specified: bool,
     fmt: &Format,
     items: impl IntoIterator<Item = &'a Item>,
 ) -> ! {
@@ -181,12 +181,12 @@ pub fn suggest_name<'a>(
 
     if fmt.verbosity > 0 {
         if names.is_empty() {
-            if search.is_empty() {
+            if search_specified {
+                safeprintln!("No matching functions, try relaxing your search request");
+            } else {
                 safeprintln!(
                     "This target defines no functions (or cargo-show-asm can't find them)"
                 );
-            } else {
-                safeprintln!("No matching functions, try relaxing your search request");
             }
             safeprintln!("You can pass --everything to see the demangled contents of a file");
         } else {
@@ -266,7 +266,7 @@ pub fn pick_dump_item<K: Clone>(
                 if filtered.is_empty() {
                     esafeprintln!("Can't find any items matching {function:?}");
                 } else {
-                    suggest_name(&function, fmt, filtered.iter().map(|x| x.0));
+                    suggest_name(!function.is_empty(), fmt, filtered.iter().map(|x| x.0));
                 }
                 std::process::exit(1);
             };
@@ -287,7 +287,7 @@ pub fn pick_dump_item<K: Clone>(
             } else {
                 // Otherwise, print suggestions and exit
                 let items = items.keys();
-                suggest_name("", fmt, items);
+                suggest_name(false, fmt, items);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,10 +239,22 @@ pub fn pick_dump_item<K: Clone>(
 
         // By index with filtering
         ToDump::Function { function, nth } => {
-            let filtered = items
+            let patterns: Vec<_> = function
                 .iter()
-                .filter(|(item, _range)| item.name.contains(&function))
-                .collect::<Vec<_>>();
+                .map(|pat| (pat.as_str(), pat.chars().all(|c| c.is_ascii_lowercase())))
+                .collect();
+            let filtered: Vec<_> = items
+                .iter()
+                .filter(|(item, _range)| {
+                    patterns.iter().all(|(pat, ignore_ascii_case)| {
+                        if *ignore_ascii_case {
+                            item.name.to_ascii_lowercase().contains(pat)
+                        } else {
+                            item.name.contains(pat)
+                        }
+                    })
+                })
+                .collect();
 
             let range = if nth.is_none()
                 && let &[(_, range)] = filtered.as_slice()

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,6 @@
 use bpaf::{Bpaf, Parser, construct, doc::Style, long, positional, short};
 use cargo_metadata::Artifact;
+use std::convert::Infallible;
 use std::path::PathBuf;
 
 fn check_target_dir(path: PathBuf) -> anyhow::Result<PathBuf> {
@@ -153,32 +154,57 @@ pub struct Cargo {
     pub unstable: Vec<String>,
 }
 
-#[derive(Debug, Clone, Bpaf)]
-/// Pick item to display from the artifact
-#[bpaf(fallback(ToDump::Unspecified))]
+#[derive(Debug, Clone)]
 pub enum ToDump {
-    /// Dump the whole file
     Everything,
-
-    #[bpaf(hide)]
     ByIndex {
-        /// Dump name with this index
-        #[bpaf(positional("ITEM_INDEX"))]
         value: usize,
     },
-
     Function {
-        /// Dump a function with a given name, filter functions by name
-        #[bpaf(positional("FUNCTION"))]
-        function: String,
-
-        /// Select specific function when there's several with the same name
-        #[bpaf(positional("INDEX"))]
+        function: Vec<String>,
         nth: Option<usize>,
     },
-
-    #[bpaf(skip)]
     Unspecified,
+}
+
+fn to_dump() -> impl Parser<ToDump> {
+    let everything = long("everything")
+        .help("Dump the whole file")
+        .req_flag(ToDump::Everything);
+
+    let functions = positional::<String>("FUNCTION")
+        .help("Dump a function with a given name, filter functions by name, multiple filters can be specified, all must match")
+        .many();
+
+    // This is just a dummy for the docs, the above `functions: Vec<String>`
+    // will absorb all arguments, which is why we use this custom parser to
+    // extract the last integer index again.
+    let dummy_index = positional::<usize>("INDEX")
+        .help("Select specific function when there's several with the same name")
+        .optional();
+
+    let positionals = construct!(functions, dummy_index).parse(
+        |(mut args, _dummy_idx)| -> Result<ToDump, Infallible> {
+            let Some(last) = args.last() else {
+                return Ok(ToDump::Unspecified);
+            };
+
+            let nth = last.parse::<usize>().ok();
+            if let Some(idx) = nth {
+                args.pop();
+                if args.is_empty() {
+                    return Ok(ToDump::ByIndex { value: idx });
+                }
+            }
+
+            Ok(ToDump::Function {
+                function: args,
+                nth,
+            })
+        },
+    );
+
+    construct!([everything, positionals]).group_help("Pick item to display from the artifact")
 }
 
 fn target_cpu() -> impl Parser<Option<String>> {


### PR DESCRIPTION
This PR improves function matching in two ways:

1. If the pattern is strictly ASCII lowercase the match is done ignoring case. That means `foo` matches `foo` and `Foo`, but `FooBar` only matches `FooBar`. Any unicode in the pattern turns this off.

2. Multiple patterns can be specified, all of them must match. That means `cargo show-asm foo bar` will match `foo::cool::bar`, but not `foo` or `bar` by itself. If the last argument is an unsigned integer it will be interpreted as the index, like before. The documentation looks as follows:

```
Usage: cargo-asm ... (--everything | [FUNCTION]... [INDEX])

...

Pick item to display from the artifact
        --everything          Dump the whole file
    FUNCTION                  Dump a function with a given name, filter functions by name, multiple
                              filters can be specified, all must match
    INDEX                     Select specific function when there's several with the same name
````


---

The motivation for this PR is that if you have a symbol like

```
4 "<cobra::raw::Clock>::enter" [23]
```

it's much easier to just write `cargo asm clock enter` with this PR than the following workflow:

1. Type `cargo asm Clock::enter`, see no results.
2. Type `cargo asm | rg -i clock`, see what I need to match on.
3. Type `cargo asm Clock>::enter`, oops, just made a file called `::enter`.
4. Type `cargo asm 'Clock>::enter'`.