### PR TITLE
Release 0.2.62

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -149,6 +149,16 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./.github/check.sh --manifest-path sample/Cargo.toml --lib --intel sample::main --rust
 
+      - name: Match by two fragments and an index
+        shell: bash
+        if: ${{ !cancelled() }}
+        run: ./.github/check.sh --manifest-path sample/Cargo.toml --lib --intel hash reserve 0
+
+      - name: Match by two fragments and no index
+        shell: bash
+        if: ${{ !cancelled() }}
+        run: ./.github/check.sh --manifest-path sample/Cargo.toml --lib --intel hash find
+
       - name: Native version of cargo-show-asm (Intel ASM) - print json
         shell: bash
         if: ${{ !cancelled() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-show-asm"
-version = "0.2.61"
+version = "0.2.62"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-show-asm"
-version = "0.2.61"
+version = "0.2.62"
 edition = "2024"
 rust-version = "1.86"
 description = "A cargo subcommand that displays the generated assembly of Rust source code."

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.2.62] - 2026-06-26
+- improved function matching (#481)
+  thanks @orlp
+- bump deps
+
 ## [0.2.61] - 2026-06-10
 - use full package ID (`id.repr`)  when passing `--package` to `cargo` (#478)
 


### PR DESCRIPTION
Main feature: smarter pattern matching.

You can specify several fragments (all must match) as well as the index to select one value from a list.

If the pattern is strictly ASCII lowercase the match is done ignoring case. That means `foo` matches `foo` and `Foo`, but `FooBar` only matches `FooBar`. Any unicode in the pattern turns this off.

See #481 for more details/motivation